### PR TITLE
Migrate assertions to AssertJ

### DIFF
--- a/dropwizard-jaxws-example/pom.xml
+++ b/dropwizard-jaxws-example/pom.xml
@@ -12,6 +12,12 @@
     <artifactId>dropwizard-jaxws-example</artifactId>
     <name>Dropwizard JAX-WS Example Application</name>
 
+    <properties>
+        <h2.version>2.2.224</h2.version>
+
+        <maven-shade-plugin.version>3.5.1</maven-shade-plugin.version>
+    </properties>
+
     <dependencies>
 
         <dependency>
@@ -59,13 +65,12 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>2.2.224</version>
+            <version>${h2.version}</version>
         </dependency>
 
         <dependency>
             <groupId>jakarta.mail</groupId>
             <artifactId>jakarta.mail-api</artifactId>
-            <version>2.1.2</version>
         </dependency>
 
         <dependency>
@@ -109,7 +114,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>${maven-shade-plugin.version}</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>

--- a/dropwizard-jaxws/pom.xml
+++ b/dropwizard-jaxws/pom.xml
@@ -69,7 +69,6 @@
         <dependency>
             <groupId>jakarta.mail</groupId>
             <artifactId>jakarta.mail-api</artifactId>
-            <version>2.1.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/ClientBuilderTest.java
+++ b/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/ClientBuilderTest.java
@@ -5,9 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import jakarta.xml.ws.handler.Handler;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 class ClientBuilderTest {
@@ -32,14 +30,14 @@ class ClientBuilderTest {
                 .cxfOutInterceptors(outInterceptor, outInterceptor)
                 .cxfOutFaultInterceptors(outFaultInterceptor, outFaultInterceptor);
 
-        assertThat(builder.getAddress(), equalTo("address"));
-        assertThat(builder.getServiceClass(), equalTo(Object.class));
-        assertThat(builder.getConnectTimeout(), equalTo(1234));
-        assertThat(builder.getReceiveTimeout(), equalTo(5678));
-        assertThat(builder.getBindingId(), equalTo("binding id"));
-        assertThat(builder.getCxfInInterceptors(), contains(new Interceptor<?>[]{ inInterceptor, inInterceptor }));
-        assertThat(builder.getCxfInFaultInterceptors(), contains(new Interceptor<?>[]{ inFaultInterceptor, inFaultInterceptor }));
-        assertThat(builder.getCxfOutInterceptors(), contains(new Interceptor<?>[]{ outInterceptor, outInterceptor }));
-        assertThat(builder.getCxfOutFaultInterceptors(), contains(new Interceptor<?>[]{ outFaultInterceptor, outFaultInterceptor }));
+        assertThat(builder.getAddress()).isEqualTo("address");
+        assertThat(builder.getServiceClass()).isEqualTo(Object.class);
+        assertThat(builder.getConnectTimeout()).isEqualTo(1234);
+        assertThat(builder.getReceiveTimeout()).isEqualTo(5678);
+        assertThat(builder.getBindingId()).isEqualTo("binding id");
+        assertThat(builder.getCxfInInterceptors()).contains(new Interceptor<?>[]{ inInterceptor, inInterceptor });
+        assertThat(builder.getCxfInFaultInterceptors()).contains(new Interceptor<?>[]{ inFaultInterceptor, inFaultInterceptor });
+        assertThat(builder.getCxfOutInterceptors()).contains(new Interceptor<?>[]{ outInterceptor, outInterceptor });
+        assertThat(builder.getCxfOutFaultInterceptors()).contains(new Interceptor<?>[]{ outFaultInterceptor, outFaultInterceptor });
     }
 }

--- a/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/EndpointBuilderTest.java
+++ b/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/EndpointBuilderTest.java
@@ -8,9 +8,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.mockito.Mockito.mock;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class EndpointBuilderTest {
 
@@ -38,15 +36,15 @@ class EndpointBuilderTest {
                 .cxfOutFaultInterceptors(outFaultInterceptor, outFaultInterceptor)
                 .properties(props);
 
-        assertThat(builder.getPath(), equalTo(path));
-        assertThat(builder.getService(), equalTo(service));
-        assertThat(builder.publishedEndpointUrl(), equalTo(publishedUrl));
-        assertThat(builder.getAuthentication(), equalTo(basicAuth));
-        assertThat(builder.getSessionFactory(), equalTo(sessionFactory));
-        assertThat(builder.getCxfInInterceptors(), contains(new Interceptor<?>[]{ inInterceptor, inInterceptor }));
-        assertThat(builder.getCxfInFaultInterceptors(), contains(new Interceptor<?>[]{ inFaultInterceptor, inFaultInterceptor }));
-        assertThat(builder.getCxfOutInterceptors(), contains(new Interceptor<?>[]{ outInterceptor, outInterceptor }));
-        assertThat(builder.getCxfOutFaultInterceptors(), contains(new Interceptor<?>[]{ outFaultInterceptor, outFaultInterceptor }));
-        assertThat(builder.getProperties().get("key"), equalTo("value"));
+        assertThat(builder.getPath()).isEqualTo(path);
+        assertThat(builder.getService()).isEqualTo(service);
+        assertThat(builder.publishedEndpointUrl()).isEqualTo(publishedUrl);
+        assertThat(builder.getAuthentication()).isEqualTo(basicAuth);
+        assertThat(builder.getSessionFactory()).isEqualTo(sessionFactory);
+        assertThat(builder.getCxfInInterceptors()).contains(new Interceptor<?>[]{ inInterceptor, inInterceptor });
+        assertThat(builder.getCxfInFaultInterceptors()).contains(new Interceptor<?>[]{ inFaultInterceptor, inFaultInterceptor });
+        assertThat(builder.getCxfOutInterceptors()).contains(new Interceptor<?>[]{ outInterceptor, outInterceptor });
+        assertThat(builder.getCxfOutFaultInterceptors()).contains(new Interceptor<?>[]{ outFaultInterceptor, outFaultInterceptor });
+        assertThat(builder.getProperties().get("key")).isEqualTo("value");
     }
 }

--- a/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/InstrumentedInvokerFactoryTest.java
+++ b/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/InstrumentedInvokerFactoryTest.java
@@ -14,11 +14,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.Mockito.*;
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 
 class InstrumentedInvokerFactoryTest {
 
@@ -103,7 +106,7 @@ class InstrumentedInvokerFactoryTest {
                     .thenReturn(InstrumentedService.class.getMethod(methodName, parameterTypes));
         }
         catch (Exception e) {
-            fail("setTargetMethod failed: " + e.getClass().getName() + ": " + e.getMessage());
+            fail("setTargetMethod failed", e);
         }
     }
 
@@ -139,10 +142,10 @@ class InstrumentedInvokerFactoryTest {
         this.setTargetMethod(exchange, "foo"); // simulate CXF behavior
 
         Object result = invoker.invoke(exchange, null);
-        assertEquals("fooReturn", result);
+        assertThat(result).isEqualTo("fooReturn");
 
-        assertThat(timer.getCount(), is(oldtimervalue));
-        assertThat(meter.getCount(), is(oldmetervalue));
+        assertThat(timer.getCount()).isEqualTo(oldtimervalue);
+        assertThat(meter.getCount()).isEqualTo(oldmetervalue);
     }
 
     @Test
@@ -160,10 +163,10 @@ class InstrumentedInvokerFactoryTest {
         this.setTargetMethod(exchange, "metered"); // simulate CXF behavior
 
         Object result = invoker.invoke(exchange, null);
-        assertEquals("meteredReturn", result);
+        assertThat(result).isEqualTo("meteredReturn");
 
-        assertThat(timer.getCount(), is(oldtimervalue));
-        assertThat(meter.getCount(), is(1 + oldmetervalue));
+        assertThat(timer.getCount()).isEqualTo(oldtimervalue);
+        assertThat(meter.getCount()).isEqualTo(1 + oldmetervalue);
     }
 
     @Test
@@ -181,10 +184,10 @@ class InstrumentedInvokerFactoryTest {
         this.setTargetMethod(exchange, "timed"); // simulate CXF behavior
 
         Object result = invoker.invoke(exchange, null);
-        assertEquals("timedReturn", result);
+        assertThat(result).isEqualTo("timedReturn");
 
-        assertThat(timer.getCount(), is(1 + oldtimervalue));
-        assertThat(meter.getCount(), is(oldmetervalue));
+        assertThat(timer.getCount()).isEqualTo(1 + oldtimervalue);
+        assertThat(meter.getCount()).isEqualTo(oldmetervalue);
     }
 
     @Test
@@ -207,11 +210,11 @@ class InstrumentedInvokerFactoryTest {
         this.setTargetMethod(exchange, "exceptionMetered", boolean.class); // simulate CXF behavior
 
         Object result = invoker.invoke(exchange, null);
-        assertEquals("exceptionMeteredReturn", result);
+        assertThat(result).isEqualTo("exceptionMeteredReturn");
 
-        assertThat(timer.getCount(), is(oldtimervalue));
-        assertThat(meter.getCount(), is(oldmetervalue));
-        assertThat(exceptionmeter.getCount(), is(oldexceptionmetervalue));
+        assertThat(timer.getCount()).isEqualTo(oldtimervalue);
+        assertThat(meter.getCount()).isEqualTo(oldmetervalue);
+        assertThat(exceptionmeter.getCount()).isEqualTo(oldexceptionmetervalue);
 
         // Invoke InstrumentedResource.exceptionMetered with exception beeing thrown
 
@@ -219,16 +222,15 @@ class InstrumentedInvokerFactoryTest {
 
         try {
             invoker.invoke(exchange, null);
-            fail("Exception shall be thrown here");
+            fail("Exception should be thrown here");
         }
         catch (Exception e) {
-            assertThat(e, is(instanceOf(RuntimeException.class)));
+            assertThat(e).isInstanceOf(RuntimeException.class);
         }
 
-        assertThat(timer.getCount(), is(oldtimervalue));
-        assertThat(meter.getCount(), is(oldmetervalue));
-        assertThat(exceptionmeter.getCount(), is(1 + oldexceptionmetervalue));
-
+        assertThat(timer.getCount()).isEqualTo(oldtimervalue);
+        assertThat(meter.getCount()).isEqualTo(oldmetervalue);
+        assertThat(exceptionmeter.getCount()).isEqualTo(1 + oldexceptionmetervalue);
     }
 
 }

--- a/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/JAXWSBundleTest.java
+++ b/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/JAXWSBundleTest.java
@@ -13,11 +13,15 @@ import jakarta.servlet.Servlet;
 import jakarta.servlet.ServletRegistration;
 import jakarta.servlet.http.HttpServlet;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class JAXWSBundleTest {
 
@@ -42,18 +46,18 @@ class JAXWSBundleTest {
     void constructorArgumentChecks() {
         try {
             new JAXWSBundle<>(null, null);
-            fail();
+            fail("expected IllegalArgumentException but no exception thrown");
         }
         catch (Exception e) {
-            assertThat(e, is(instanceOf(IllegalArgumentException.class)));
+            assertThat(e).isInstanceOf(IllegalArgumentException.class);
         }
 
         try {
             new JAXWSBundle<>("soap", null);
-            fail();
+            fail("expected IllegalArgumentException but no exception thrown");
         }
         catch (Exception e) {
-            assertThat(e, is(instanceOf(IllegalArgumentException.class)));
+            assertThat(e).isInstanceOf(IllegalArgumentException.class);
         }
     }
 
@@ -65,7 +69,7 @@ class JAXWSBundleTest {
             jaxwsBundle.run(null, null);
         }
         catch (Exception e) {
-            assertThat(e, is(instanceOf(IllegalArgumentException.class)));
+            assertThat(e).isInstanceOf(IllegalArgumentException.class);
         }
 
         jaxwsBundle.initialize(bootstrap);
@@ -91,7 +95,7 @@ class JAXWSBundleTest {
             jaxwsBundle.run(null, null);
         }
         catch (Exception e) {
-            assertThat(e, is(instanceOf(IllegalArgumentException.class)));
+            assertThat(e).isInstanceOf(IllegalArgumentException.class);
         }
 
         jaxwsBundle.initialize(bootstrap);
@@ -111,26 +115,26 @@ class JAXWSBundleTest {
         Object service = new Object();
         try {
             jaxwsBundle.publishEndpoint(new EndpointBuilder("foo", null));
-            fail();
+            fail("expected IllegalArgumentException but no exception thrown");
         }
         catch (Exception e) {
-            assertThat(e, is(instanceOf(IllegalArgumentException.class)));
+            assertThat(e).isInstanceOf(IllegalArgumentException.class);
         }
 
         try {
             jaxwsBundle.publishEndpoint(new EndpointBuilder(null, service));
-            fail();
+            fail("expected IllegalArgumentException but no exception thrown");
         }
         catch (Exception e) {
-            assertThat(e, is(instanceOf(IllegalArgumentException.class)));
+            assertThat(e).isInstanceOf(IllegalArgumentException.class);
         }
 
         try {
             jaxwsBundle.publishEndpoint(new EndpointBuilder("   ", service));
-            fail();
+            fail("expected IllegalArgumentException but no exception thrown");
         }
         catch (Exception e) {
-            assertThat(e, is(instanceOf(IllegalArgumentException.class)));
+            assertThat(e).isInstanceOf(IllegalArgumentException.class);
         }
 
         EndpointBuilder builder = mock(EndpointBuilder.class);
@@ -148,27 +152,27 @@ class JAXWSBundleTest {
 
         try {
             jaxwsBundle.getClient(new ClientBuilder<>(null, null));
-            fail();
+            fail("expected IllegalArgumentException but no exception thrown");
         }
 
         catch (Exception e) {
-            assertThat(e, is(instanceOf(IllegalArgumentException.class)));
+            assertThat(e).isInstanceOf(IllegalArgumentException.class);
         }
 
         try {
             jaxwsBundle.getClient(new ClientBuilder<>(null, url));
-            fail();
+            fail("expected IllegalArgumentException but no exception thrown");
         }
         catch (Exception e) {
-            assertThat(e, is(instanceOf(IllegalArgumentException.class)));
+            assertThat(e).isInstanceOf(IllegalArgumentException.class);
         }
 
         try {
             jaxwsBundle.getClient(new ClientBuilder<>(cls, "   "));
-            fail();
+            fail("expected IllegalArgumentException but no exception thrown");
         }
         catch (Exception e) {
-            assertThat(e, is(instanceOf(IllegalArgumentException.class)));
+            assertThat(e).isInstanceOf(IllegalArgumentException.class);
         }
 
         ClientBuilder<?> builder = new ClientBuilder<>(cls, url);

--- a/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/JAXWSEnvironmentTest.java
+++ b/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/JAXWSEnvironmentTest.java
@@ -40,12 +40,7 @@ import jakarta.xml.ws.soap.SOAPBinding;
 import java.lang.reflect.Proxy;
 import java.util.HashMap;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -132,15 +127,15 @@ class JAXWSEnvironmentTest {
     @Test
     void buildServlet() {
         Object result = jaxwsEnvironment.buildServlet();
-        assertThat(result, is(instanceOf(CXFNonSpringServlet.class)));
-        assertThat(((CXFNonSpringServlet) result).getBus(), is(instanceOf(Bus.class)));
+        assertThat(result).isInstanceOf(CXFNonSpringServlet.class);
+        assertThat(((CXFNonSpringServlet) result).getBus()).isInstanceOf(Bus.class);
     }
 
     @Test
     void publishEndpoint() throws Exception {
 
         Endpoint e = jaxwsEnvironment.publishEndpoint(new EndpointBuilder("local://path", service));
-        assertThat(e, is(notNullValue()));
+        assertThat(e).isNotNull();
 
         verify(mockInvokerBuilder).create(any(), any(Invoker.class));
         verifyNoInteractions(mockUnitOfWorkInvokerBuilder);
@@ -193,7 +188,7 @@ class JAXWSEnvironmentTest {
 
         testutils.assertValid("/soap:Envelope/soap:Body/a:fooResponse", soapResponse);
 
-        assertThat(mockBasicAuthInterceptorInvoked, equalTo(1));
+        assertThat(mockBasicAuthInterceptorInvoked).isEqualTo(1);
     }
 
     @Test
@@ -232,9 +227,9 @@ class JAXWSEnvironmentTest {
                 LocalTransportFactory.TRANSPORT_ID, soapRequest);
 
         verify(mockInvoker).invoke(any(Exchange.class), any());
-        assertThat(inInterceptor.getInvocationCount(), equalTo(1));
-        assertThat(inInterceptor2.getInvocationCount(), equalTo(1));
-        assertThat(outInterceptor.getInvocationCount(), equalTo(1));
+        assertThat(inInterceptor.getInvocationCount()).isEqualTo(1);
+        assertThat(inInterceptor2.getInvocationCount()).isEqualTo(1);
+        assertThat(outInterceptor.getInvocationCount()).isEqualTo(1);
 
         testutils.assertValid("/soap:Envelope/soap:Body/a:fooResponse", soapResponse);
 
@@ -242,9 +237,9 @@ class JAXWSEnvironmentTest {
                 LocalTransportFactory.TRANSPORT_ID, soapRequest);
 
         verify(mockInvoker, times(2)).invoke(any(Exchange.class), any());
-        assertThat(inInterceptor.getInvocationCount(), equalTo(2));
-        assertThat(inInterceptor2.getInvocationCount(), equalTo(2));
-        assertThat(outInterceptor.getInvocationCount(), equalTo(2));
+        assertThat(inInterceptor.getInvocationCount()).isEqualTo(2);
+        assertThat(inInterceptor2.getInvocationCount()).isEqualTo(2);
+        assertThat(outInterceptor.getInvocationCount()).isEqualTo(2);
 
         testutils.assertValid("/soap:Envelope/soap:Body/a:fooResponse", soapResponse);
     }
@@ -265,7 +260,7 @@ class JAXWSEnvironmentTest {
 
         MimeMultipart mimeMultipart = new MimeMultipart(new ByteArrayDataSource(response,
                 "application/xop+xml; charset=UTF-8; type=\"text/xml\""));
-        assertThat(mimeMultipart.getCount(), equalTo(1));
+        assertThat(mimeMultipart.getCount()).isEqualTo(1);
         testutils.assertValid("/soap:Envelope/soap:Body/a:fooResponse",
                 StaxUtils.read(mimeMultipart.getBodyPart(0).getInputStream()));
     }
@@ -285,7 +280,7 @@ class JAXWSEnvironmentTest {
         AbstractDestination destination = (AbstractDestination) server.getDestination();
         String publishedEndpointUrl = destination.getEndpointInfo().getProperty(WSDLGetUtils.PUBLISHED_ENDPOINT_URL, String.class);
 
-        assertThat(publishedEndpointUrl, equalTo("http://external.server/external/path"));
+        assertThat(publishedEndpointUrl).isEqualTo("http://external.server/external/path");
     }
 
     @Test
@@ -298,8 +293,8 @@ class JAXWSEnvironmentTest {
                 new EndpointBuilder("local://path", service)
                     .properties(props));
 
-        assertThat(e, is(notNullValue()));
-        assertThat(e.getProperties().get("key"), equalTo("value"));
+        assertThat(e).isNotNull();
+        assertThat(e.getProperties().get("key")).isEqualTo("value");
 
         verify(mockInvokerBuilder).create(any(), any(Invoker.class));
         verifyNoInteractions(mockUnitOfWorkInvokerBuilder);
@@ -328,7 +323,7 @@ class JAXWSEnvironmentTest {
         AbstractDestination destination = (AbstractDestination) server.getDestination();
         String publishedEndpointUrl = destination.getEndpointInfo().getProperty(WSDLGetUtils.PUBLISHED_ENDPOINT_URL, String.class);
 
-        assertThat(publishedEndpointUrl, equalTo("http://external/prefix/path"));
+        assertThat(publishedEndpointUrl).isEqualTo("http://external/prefix/path");
     }
 
     @Test
@@ -363,16 +358,16 @@ class JAXWSEnvironmentTest {
         DummyInterface clientProxy = jaxwsEnvironment.getClient(
                 new ClientBuilder<>(DummyInterface.class, address)
         );
-        assertThat(clientProxy, is(instanceOf(Proxy.class)));
+        assertThat(clientProxy).isInstanceOf(Proxy.class);
 
         Client c = ClientProxy.getClient(clientProxy);
-        assertThat(c.getEndpoint().getEndpointInfo().getAddress(), equalTo(address));
-        assertThat(c.getEndpoint().getService().get("endpoint.class").equals(DummyInterface.class), equalTo(true));
-        assertThat(((BindingProvider)clientProxy).getBinding() .getHandlerChain().size(), equalTo(0));
+        assertThat(c.getEndpoint().getEndpointInfo().getAddress()).isEqualTo(address);
+        assertThat(c.getEndpoint().getService().get("endpoint.class").equals(DummyInterface.class)).isEqualTo(true);
+        assertThat(((BindingProvider)clientProxy).getBinding() .getHandlerChain().size()).isEqualTo(0);
 
         HTTPClientPolicy httpclient = ((HTTPConduit)c.getConduit()).getClient();
-        assertThat(httpclient.getConnectionTimeout(), equalTo(500L));
-        assertThat(httpclient.getReceiveTimeout(), equalTo(2000L));
+        assertThat(httpclient.getConnectionTimeout()).isEqualTo(500L);
+        assertThat(httpclient.getReceiveTimeout()).isEqualTo(2000L);
 
         // with timeouts, handlers, interceptors, properties and MTOM
 
@@ -390,18 +385,18 @@ class JAXWSEnvironmentTest {
                         .cxfOutInterceptors(outInterceptor)
                         .enableMtom());
         c = ClientProxy.getClient(clientProxy);
-        assertThat(((BindingProvider) clientProxy).getBinding().getBindingID(), equalTo("http://www.w3.org/2003/05/soap/bindings/HTTP/"));
-        assertThat(c.getEndpoint().getEndpointInfo().getAddress(), equalTo(address));
-        assertThat(c.getEndpoint().getService().get("endpoint.class").equals(DummyInterface.class), equalTo(true));
+        assertThat(((BindingProvider) clientProxy).getBinding().getBindingID()).isEqualTo("http://www.w3.org/2003/05/soap/bindings/HTTP/");
+        assertThat(c.getEndpoint().getEndpointInfo().getAddress()).isEqualTo(address);
+        assertThat(c.getEndpoint().getService().get("endpoint.class").equals(DummyInterface.class)).isEqualTo(true);
 
         httpclient = ((HTTPConduit)c.getConduit()).getClient();
-        assertThat(httpclient.getConnectionTimeout(), equalTo(123L));
-        assertThat(httpclient.getReceiveTimeout(), equalTo(456L));
+        assertThat(httpclient.getConnectionTimeout()).isEqualTo(123L);
+        assertThat(httpclient.getReceiveTimeout()).isEqualTo(456L);
 
-        assertThat(((BindingProvider)clientProxy).getBinding().getHandlerChain(), contains(handler));
+        assertThat(((BindingProvider)clientProxy).getBinding().getHandlerChain()).contains(handler);
 
         BindingProvider bp = (BindingProvider)clientProxy;
         SOAPBinding binding = (SOAPBinding)bp.getBinding();
-        assertThat(binding.isMTOMEnabled(), equalTo(true));
+        assertThat(binding.isMTOMEnabled()).isEqualTo(true);
     }
 }

--- a/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/UnitOfWorkInvokerFactoryTest.java
+++ b/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/UnitOfWorkInvokerFactoryTest.java
@@ -14,8 +14,8 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -94,7 +94,7 @@ class UnitOfWorkInvokerFactoryTest {
                     .thenReturn(FooService.class.getMethod(methodName, parameterTypes));
         }
         catch (Exception e) {
-            fail("setTargetMethod failed: " + e.getClass().getName() + ": " + e.getMessage());
+            fail("setTargetMethod failed", e);
         }
     }
 
@@ -104,7 +104,7 @@ class UnitOfWorkInvokerFactoryTest {
         this.setTargetMethod(exchange, "foo"); // simulate CXF behavior
 
         Object result = invoker.invoke(exchange, null);
-        assertEquals("foo return", result);
+        assertThat(result).isEqualTo("foo return");
 
         verifyNoInteractions(sessionFactory);
         verifyNoInteractions(session);
@@ -118,7 +118,7 @@ class UnitOfWorkInvokerFactoryTest {
         this.setTargetMethod(exchange, "unitOfWork", boolean.class); // simulate CXF behavior
 
         Object result = invoker.invoke(exchange, null);
-        assertEquals("unitOfWork return", result);
+        assertThat(result).isEqualTo("unitOfWork return");
 
         verify(session, times(1)).beginTransaction();
         verify(transaction, times(1)).commit();
@@ -136,7 +136,7 @@ class UnitOfWorkInvokerFactoryTest {
             invoker.invoke(exchange, null);
         }
         catch (Exception e) {
-            assertEquals("Uh oh", e.getMessage());
+            assertThat(e.getMessage()).isEqualTo("Uh oh");
         }
 
         verify(session, times(1)).beginTransaction();

--- a/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/ValidatingInvokerTest.java
+++ b/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/ValidatingInvokerTest.java
@@ -21,11 +21,12 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 class ValidatingInvokerTest {
 
@@ -100,7 +101,7 @@ class ValidatingInvokerTest {
                     .thenReturn(DummyService.class.getMethod(methodName, parameterTypes));
         }
         catch (Exception e) {
-            fail("setTargetMethod failed: " + e.getClass().getName() + ": " + e.getMessage());
+            fail("setTargetMethod failed", e);
         }
     }
 
@@ -156,28 +157,28 @@ class ValidatingInvokerTest {
 
         try {
             invoker.invoke(exchange, params);
-            fail();
+            fail("expected ValidationException but no exception thrown");
         }
         catch(Exception e) {
-            assertThat(e, is(instanceOf(ValidationException.class)));
+            assertThat(e).isInstanceOf(ValidationException.class);
         }
 
         params = Arrays.asList(new RootParam1(new ChildParam("")), new RootParam2("ok"));
         try {
             invoker.invoke(exchange, params);
-            fail();
+            fail("expected ValidationException but no exception thrown");
         }
         catch(Exception e) {
-            assertThat(e, is(instanceOf(ValidationException.class)));
+            assertThat(e).isInstanceOf(ValidationException.class);
         }
 
         params = Arrays.asList(new RootParam1(new ChildParam("John")), new RootParam2("ok"));
         try {
             invoker.invoke(exchange, params);
-            fail();
+            fail("expected ValidationException but no exception thrown");
         }
         catch(Exception e) {
-            assertThat(e, is(instanceOf(ValidationException.class)));
+            assertThat(e).isInstanceOf(ValidationException.class);
         }
 
         verifyNoMoreInteractions(underlying);

--- a/pom.xml
+++ b/pom.xml
@@ -21,14 +21,26 @@
     </modules>
 
     <properties>
+        <java.version>17</java.version>
+
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <dropwizard.version>4.0.3</dropwizard.version>
         <cxf.version>4.0.3</cxf.version>
-        <junit.version>5.10.1</junit.version>
+        <jakarta.mail-api.version>2.1.2</jakarta.mail-api.version>
 
+        <assertj.version>3.24.2</assertj.version>
+        <junit.version>5.10.1</junit.version>
+        <mockito.version>5.7.0</mockito.version>
+
+        <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
         <maven-enforcer-plugin.version>3.4.1</maven-enforcer-plugin.version>
+        <maven-gpg-plugin.version>3.1.0</maven-gpg-plugin.version>
+        <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
+        <maven-javadoc-plugin.version>3.6.0</maven-javadoc-plugin.version>
+        <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
+        <versions-maven-plugin.version>2.16.1</versions-maven-plugin.version>
 
     </properties>
 
@@ -81,7 +93,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.1.0</version>
+                        <version>${maven-gpg-plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -96,7 +108,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>3.3.0</version>
+                        <version>${maven-source-plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -110,7 +122,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.6.0</version>
+                        <version>${maven-javadoc-plugin.version}</version>
                         <configuration>
                             <quiet>true</quiet>
                             <additionalparam>-Xdoclint:none</additionalparam>
@@ -150,10 +162,23 @@
                 <scope>import</scope>
             </dependency>
 
+            <dependency>
+                <groupId>jakarta.mail</groupId>
+                <artifactId>jakarta.mail-api</artifactId>
+                <version>${jakarta.mail-api.version}</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+          </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -164,14 +189,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.7.0</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest</artifactId>
-            <version>2.2</version>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -183,9 +201,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
+                <version>${maven-compiler-plugin.version}</version>
                 <configuration>
-                    <release>17</release>
+                    <release>${java.version}</release>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
@@ -193,7 +211,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>${maven-jar-plugin.version}</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -206,7 +224,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
-                <version>2.16.1</version>
+                <version>${versions-maven-plugin.version}</version>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
* Thanks @openrewrite (even though only the AssertJ migration worked)
* Migrate JUnit and Hamcrest assertions to AssertJ
* Extract versions to properties in the POM files

Closes #18