### PR TITLE
Misc. code cleanup

### DIFF
--- a/dropwizard-jaxws-example/src/main/java/com/roskart/dropwizard/jaxws/example/JaxWsExampleApplication.java
+++ b/dropwizard-jaxws-example/src/main/java/com/roskart/dropwizard/jaxws/example/JaxWsExampleApplication.java
@@ -49,6 +49,7 @@ public class JaxWsExampleApplication extends Application<JaxWsExampleApplication
     public void run(JaxWsExampleApplicationConfiguration jaxWsExampleApplicationConfiguration, Environment environment) {
 
         // Hello world service
+        @SuppressWarnings("unused")
         EndpointImpl e = jaxWsBundle.publishEndpoint(
                 new EndpointBuilder("/simple", new SimpleService()));
 

--- a/dropwizard-jaxws-example/src/main/java/com/roskart/dropwizard/jaxws/example/db/PersonDAO.java
+++ b/dropwizard-jaxws-example/src/main/java/com/roskart/dropwizard/jaxws/example/db/PersonDAO.java
@@ -23,8 +23,8 @@ public class PersonDAO extends AbstractDAO<Person> {
         try {
             sess.beginTransaction();
             sess.createNativeQuery("create table people(id bigint primary key auto_increment not null, " +
-                    "fullname varchar(256) not null, jobtitle varchar(256) not null);").executeUpdate();
-            sess.createNativeQuery("create sequence hibernate_sequence").executeUpdate();
+                    "fullname varchar(256) not null, jobtitle varchar(256) not null);", Void.class).executeUpdate();
+            sess.createNativeQuery("create sequence hibernate_sequence", Void.class).executeUpdate();
         }
         finally {
             sess.getTransaction().commit();

--- a/dropwizard-jaxws-example/src/main/java/com/roskart/dropwizard/jaxws/example/resources/AccessMtomServiceResource.java
+++ b/dropwizard-jaxws-example/src/main/java/com/roskart/dropwizard/jaxws/example/resources/AccessMtomServiceResource.java
@@ -9,6 +9,7 @@ import ws.example.jaxws.dropwizard.roskart.com.mtomservice.ObjectFactory;
 
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 
 import jakarta.activation.DataHandler;
 import jakarta.mail.util.ByteArrayDataSource;
@@ -43,7 +44,7 @@ public class AccessMtomServiceResource {
                     IOUtils.readStringFromStream(hr.getBinary().getInputStream());
         }
         catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/dropwizard-jaxws/src/main/java/com/roskart/dropwizard/jaxws/BasicAuthenticationInterceptor.java
+++ b/dropwizard-jaxws/src/main/java/com/roskart/dropwizard/jaxws/BasicAuthenticationInterceptor.java
@@ -89,7 +89,7 @@ public class BasicAuthenticationInterceptor extends AbstractPhaseInterceptor<Mes
         outMessage.put(Message.RESPONSE_CODE, responseCode);
         // Set the response headers
         @SuppressWarnings("unchecked")
-        Map<String, List<String>> responseHeaders = (Map)message.get(Message.PROTOCOL_HEADERS);
+        var responseHeaders = (Map<String, List<String>>) message.get(Message.PROTOCOL_HEADERS);
         if (responseHeaders != null) {
             responseHeaders.put("WWW-Authenticate", Collections.singletonList("Basic realm=" + authentication.getRealm()));
             responseHeaders.put("Content-length", Collections.singletonList("0"));

--- a/dropwizard-jaxws/src/main/java/com/roskart/dropwizard/jaxws/EndpointBuilder.java
+++ b/dropwizard-jaxws/src/main/java/com/roskart/dropwizard/jaxws/EndpointBuilder.java
@@ -81,14 +81,12 @@ public class EndpointBuilder extends AbstractBuilder {
 
     @Override
     @SafeVarargs
-    @SuppressWarnings("unchecked")
     public final EndpointBuilder cxfInInterceptors(Interceptor<? extends Message>... interceptors) {
         return (EndpointBuilder)super.cxfInInterceptors(interceptors);
     }
 
     @Override
     @SafeVarargs
-    @SuppressWarnings("unchecked")
     public final EndpointBuilder cxfInFaultInterceptors(Interceptor<? extends Message>... interceptors) {
         return (EndpointBuilder)super.cxfInFaultInterceptors(interceptors);
     }
@@ -102,7 +100,6 @@ public class EndpointBuilder extends AbstractBuilder {
 
     @Override
     @SafeVarargs
-    @SuppressWarnings("unchecked")
     public final EndpointBuilder cxfOutFaultInterceptors(Interceptor<? extends Message>... interceptors) {
         return (EndpointBuilder)super.cxfOutFaultInterceptors(interceptors);
     }

--- a/dropwizard-jaxws/src/main/java/com/roskart/dropwizard/jaxws/InstrumentedInvokerFactory.java
+++ b/dropwizard-jaxws/src/main/java/com/roskart/dropwizard/jaxws/InstrumentedInvokerFactory.java
@@ -85,11 +85,13 @@ public class InstrumentedInvokerFactory {
             if (absolute) {
                 return explicitName;
             }
-            return metricRegistry.name(method.getDeclaringClass(), explicitName);
+            return MetricRegistry.name(method.getDeclaringClass(), explicitName);
         }
-        return metricRegistry.name(metricRegistry.name(method.getDeclaringClass(),
+        return MetricRegistry.name(
+                MetricRegistry.name(method.getDeclaringClass(),
                 method.getName()),
-                suffixes);
+                suffixes
+        );
     }
 
     /**

--- a/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/JAXWSBundleTest.java
+++ b/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/JAXWSBundleTest.java
@@ -13,7 +13,6 @@ import jakarta.servlet.Servlet;
 import jakarta.servlet.ServletRegistration;
 import jakarta.servlet.http.HttpServlet;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.ArgumentMatchers.any;
@@ -65,12 +64,9 @@ class JAXWSBundleTest {
     void initializeAndRun() {
         JAXWSBundle<?> jaxwsBundle = new JAXWSBundle<>("/soap", jaxwsEnvironment);
 
-        try {
-            jaxwsBundle.run(null, null);
-        }
-        catch (Exception e) {
-            assertThat(e).isInstanceOf(IllegalArgumentException.class);
-        }
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> jaxwsBundle.run(null, null))
+                .withMessage("Environment is null");
 
         jaxwsBundle.initialize(bootstrap);
         verify(jaxwsEnvironment).setInstrumentedInvokerBuilder(any(InstrumentedInvokerFactory.class));
@@ -91,12 +87,9 @@ class JAXWSBundleTest {
             }
         };
 
-        try {
-            jaxwsBundle.run(null, null);
-        }
-        catch (Exception e) {
-            assertThat(e).isInstanceOf(IllegalArgumentException.class);
-        }
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> jaxwsBundle.run(null, null))
+                .withMessage("Environment is null");
 
         jaxwsBundle.initialize(bootstrap);
         verify(jaxwsEnvironment).setInstrumentedInvokerBuilder(any(InstrumentedInvokerFactory.class));

--- a/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/JAXWSEnvironmentTest.java
+++ b/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/JAXWSEnvironmentTest.java
@@ -41,6 +41,7 @@ import java.lang.reflect.Proxy;
 import java.util.HashMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -329,30 +330,24 @@ class JAXWSEnvironmentTest {
     @Test
     void publishEndpointWithInvalidArguments() throws Exception {
 
-        try {
-            jaxwsEnvironment.publishEndpoint(new EndpointBuilder("foo", null));
-        }
-        catch (IllegalArgumentException e) {
-        }
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new EndpointBuilder("foo", null))
+                .withMessage("Service is null");
 
-        try {
-            jaxwsEnvironment.publishEndpoint(new EndpointBuilder(null, service));
-        }
-        catch (IllegalArgumentException e) {
-        }
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new EndpointBuilder(null, service))
+                .withMessage("Path is null");
 
-        try {
-            jaxwsEnvironment.publishEndpoint(new EndpointBuilder("   ", service));
-        }
-        catch (IllegalArgumentException e) {
-        }
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new EndpointBuilder("   ", service))
+                .withMessage("Path is empty");
     }
 
     @Test
     void getClient() {
 
-        String address = "http://address";
-        Handler handler = mock(Handler.class);
+        var address = "http://address";
+        var handler = mock(Handler.class);
 
         // simple
         DummyInterface clientProxy = jaxwsEnvironment.getClient(

--- a/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/UnitOfWorkInvokerFactoryTest.java
+++ b/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/UnitOfWorkInvokerFactoryTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.Method;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatRuntimeException;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -130,14 +131,11 @@ class UnitOfWorkInvokerFactoryTest {
     void unitOfWorkWithException() {
         // use underlying invoker which invokes fooService.unitOfWork(true) - exception is thrown
         Invoker invoker = invokerBuilder.create(fooService, new UnitOfWorkInvoker(true), sessionFactory);
-        this.setTargetMethod(exchange, "unitOfWork", boolean.class); // simulate CXF behavior
+        this.setTargetMethod(exchange, "unitOfWork", boolean.class);  // simulate CXF behavior
 
-        try {
-            invoker.invoke(exchange, null);
-        }
-        catch (Exception e) {
-            assertThat(e.getMessage()).isEqualTo("Uh oh");
-        }
+        assertThatRuntimeException()
+                .isThrownBy(() -> invoker.invoke(exchange, null))
+                .withMessage("Uh oh");
 
         verify(session, times(1)).beginTransaction();
         verify(transaction, times(0)).commit();

--- a/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/ValidatingInvokerTest.java
+++ b/dropwizard-jaxws/src/test/java/com/roskart/dropwizard/jaxws/ValidatingInvokerTest.java
@@ -65,16 +65,21 @@ class ValidatingInvokerTest {
     class DummyService {
         public void noParams() {
         }
+
         public void noValidation(RootParam1 rootParam1, RootParam2 rootParam2) {
         }
+
         public void withValidation(@Valid RootParam1 rootParam1, @Valid RootParam2 rootParam2) {
         }
+
         public void withDropwizardValidation(@Validated() String foo) {
         }
+
         @UseAsyncMethod
         public void asyncMethod(String foo) {
         }
-        public void asyncMethodAsync(String foo, AsyncHandler asyncHandler) {
+
+        public void asyncMethodAsync(String foo, AsyncHandler<String> asyncHandler) {
         }
     }
 
@@ -129,18 +134,18 @@ class ValidatingInvokerTest {
     void invokeWithAsycHandler() {
         setTargetMethod(exchange, "asyncMethod", String.class);
 
-        List<Object> params = Arrays.<Object>asList(null, new AsyncHandler(){
+        List<Object> params = Arrays.<Object>asList(null, new AsyncHandler<String>() {
             @Override
-            public void handleResponse(Response res) {
+            public void handleResponse(Response<String> res) {
 
             }
         });
         invoker.invoke(exchange, params);
         verify(underlying).invoke(exchange, params);
 
-        params = Arrays.asList("foo", new AsyncHandler(){
+        params = Arrays.asList("foo", new AsyncHandler<String>() {
             @Override
-            public void handleResponse(Response res) {
+            public void handleResponse(Response<String> res) {
 
             }
         });


### PR DESCRIPTION
* Remove redundant warning suppression annotations in endpointBuilder
* Resolve use of raw Map type in case in BasicAuthenticationInterceptor
* Minor code reformatting in InstrumentedInvokerFactory for readability
* Use assertThatIllegalArgumentException in JAXWSBundleTest and in JAXWSEnvironmentTest
* Use assertThatRuntimeException in UnitOfWorkInvokerFactoryTest
* Fix raw usage of AsyncHandler in ValidatingInvokerTest
* Suppress unused var warning in JaxWsExampleApplication#run
* Fix deprecated code warnings in PersonDAO
* Change AccessMtomServiceResource to throw UncheckedIOException instead of just RuntimeException