### PR TITLE
Sonar cleanup in AbstractInvoker

### DIFF
--- a/dropwizard-jaxws/src/main/java/com/roskart/dropwizard/jaxws/AbstractInvoker.java
+++ b/dropwizard-jaxws/src/main/java/com/roskart/dropwizard/jaxws/AbstractInvoker.java
@@ -23,10 +23,9 @@ public abstract class AbstractInvoker implements Invoker {
 
         Object o = exchange.getBindingOperationInfo().getOperationInfo().getProperty(Method.class.getName());
 
-        if (o instanceof Method) {
-            return (Method)o;
-        }
-        else {
+        if (o instanceof Method method) {
+            return method;
+        } else {
             throw new RuntimeException("Target method not found on OperationInfo");
         }
 
@@ -36,9 +35,9 @@ public abstract class AbstractInvoker implements Invoker {
     public abstract Object invoke(Exchange exchange, Object o);
 
     /**
-     *  Rethrows exception, without requiring to handle checked exception.
-     *  Type-erasure happens at compile time, therefore if E is RuntimeException,
-     *  checked exception can be re-thrown without declaring them.
+     * Rethrows exception, without requiring to handle checked exception.
+     * Type-erasure happens at compile time, therefore if E is RuntimeException,
+     * checked exception can be re-thrown without declaring them.
      */
     @SuppressWarnings("unchecked")
     protected <E extends Exception> void rethrow(Exception e) throws E {

--- a/dropwizard-jaxws/src/main/java/com/roskart/dropwizard/jaxws/AbstractInvoker.java
+++ b/dropwizard-jaxws/src/main/java/com/roskart/dropwizard/jaxws/AbstractInvoker.java
@@ -31,9 +31,6 @@ public abstract class AbstractInvoker implements Invoker {
 
     }
 
-    @Override
-    public abstract Object invoke(Exchange exchange, Object o);
-
     /**
      * Rethrows exception, without requiring to handle checked exception.
      * Type-erasure happens at compile time, therefore if E is RuntimeException,

--- a/dropwizard-jaxws/src/main/java/com/roskart/dropwizard/jaxws/AbstractInvoker.java
+++ b/dropwizard-jaxws/src/main/java/com/roskart/dropwizard/jaxws/AbstractInvoker.java
@@ -23,7 +23,7 @@ public abstract class AbstractInvoker implements Invoker {
 
         Object o = exchange.getBindingOperationInfo().getOperationInfo().getProperty(Method.class.getName());
 
-        if (o != null && o instanceof Method) {
+        if (o instanceof Method) {
             return (Method)o;
         }
         else {

--- a/dropwizard-jaxws/src/main/java/com/roskart/dropwizard/jaxws/AbstractInvoker.java
+++ b/dropwizard-jaxws/src/main/java/com/roskart/dropwizard/jaxws/AbstractInvoker.java
@@ -26,7 +26,7 @@ public abstract class AbstractInvoker implements Invoker {
         if (o instanceof Method method) {
             return method;
         } else {
-            throw new RuntimeException("Target method not found on OperationInfo");
+            throw new IllegalStateException("Target method not found on OperationInfo");
         }
 
     }

--- a/dropwizard-jaxws/src/main/java/com/roskart/dropwizard/jaxws/AbstractInvoker.java
+++ b/dropwizard-jaxws/src/main/java/com/roskart/dropwizard/jaxws/AbstractInvoker.java
@@ -12,7 +12,7 @@ public abstract class AbstractInvoker implements Invoker {
 
     protected Invoker underlying;
 
-    public AbstractInvoker(Invoker underlying) {
+    protected AbstractInvoker(Invoker underlying) {
         this.underlying = underlying;
     }
 


### PR DESCRIPTION
* Make constructor of AbstractInvoker protected (java:S5993 - Constructors of an "abstract" class should not be declared "public")
* Remove unnecessary null check in AbstractInvoker (java:S4201 - Null checks should not be used with "instanceof")
* Remove null check and use pattern matching in AbstractInvoker (java:S4201 - Null checks should not be used with "instanceof";  java:S6201 - Pattern Matching for "instanceof" operator should be used instead of simple "instanceof" + cast)
* Remove redundant abstract method in AbstractInvoker (java:S3038 Abstract methods should not be redundant)
* Throw dedicated exception in AbstractInvoker. Throw an IllegalStateException instead of RuntimeException
when the target method can't be found (java:S112 - Generic exceptions should never be thrown)

