### PR TITLE
POM dependency cleanup

### DIFF
--- a/dropwizard-jaxws-example/pom.xml
+++ b/dropwizard-jaxws-example/pom.xml
@@ -15,6 +15,7 @@
 
     <properties>
         <h2.version>2.2.224</h2.version>
+        <saaj-impl.version>3.0.3</saaj-impl.version>
 
         <maven-shade-plugin.version>3.5.1</maven-shade-plugin.version>
     </properties>
@@ -31,6 +32,7 @@
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
             <exclusions>
+                <!-- TODO: Can these exclusions be removed? -->
                 <!-- Exclude JAXB API 2.3.2 and activation API 1.2.1 that are used by jackson-jaxrs-json-provider
                 to prevent duplicate class warnings when building fat jar (dropwizard-jersey depends on JAXB API
                 2.3.1 and activation API 1.2.0 ). -->
@@ -55,6 +57,7 @@
             <artifactId>dropwizard-hibernate</artifactId>
             <exclusions>
                 <exclusion>
+                    <!-- TODO: Can this exclusion be removed? -->
                     <!-- Exclude JTA 1.3 API from jackson-datatype-hibernate5 to prevent duplicate class warnings
                     when building fat jar (hibernate-core depends on JTA 1.2 API). -->
                     <groupId>javax.transaction</groupId>
@@ -78,6 +81,12 @@
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-features-logging</artifactId>
             <version>${cxf.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.sun.xml.messaging.saaj</groupId>
+            <artifactId>saaj-impl</artifactId>
+            <version>${saaj-impl.version}</version>
         </dependency>
 
     </dependencies>

--- a/dropwizard-jaxws/pom.xml
+++ b/dropwizard-jaxws/pom.xml
@@ -37,6 +37,7 @@
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
             <version>${cxf.version}</version>
+            <!-- TODO: Can this be removed? -->
             <exclusions>
                 <!-- jaxb-core 2.2.7 contains classes from istack-commons-runtime 2.16
                 and it also has dependency on istack-commons-runtime 2.16 -->

--- a/pom.xml
+++ b/pom.xml
@@ -32,18 +32,19 @@
 
         <!--
         NOTE:
-        We are using Jakarta Persistence and Transaction APIs from Jakarta EE 10 here, but using
-        the JAXB runtime version compatible with Jakarta EE 9. I think this will work because
-        Dropwizard 4.x is using Hibernate 6.1.x which says (see https://hibernate.org/orm/releases/6.1/)
+        We are using Jakarta Persistence and Transaction APIs from Jakarta EE 10 here. I think this will work
+        because Dropwizard 4.x is using Hibernate 6.1.x which says (see https://hibernate.org/orm/releases/6.1/)
         it is compatible with both Jakarta Persistence 3.1 (Jakarta EE 10) and 3.0 (Jakarta EE 9).
         The kiwi-bom uses Hibernate 6.3.x which is compatible with Jakarta Persistence 3.1 (Jakarta EE 10)
         and it seems to work fine with Dropwizard 4.x. Plus, Hibernate 6.1.x is EOL (end-of-life) so we
-        don't really want to be using it. But, we are also mandating the JAXB runtime version that is
-        Jakarta EE 9 compatible, since that is what Dropwizard 4.x is compatible with.
+        don't really want to be using it. Also, we are also mandating the JAXB runtime version that is
+        Jakarta EE 10 compatible, because even though Dropwizard 4.x is compatible with Jakarta EE 9, it still
+        seems to work just fine.
         -->
         <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version>
         <jakarta.transaction-api.version>2.0.1</jakarta.transaction-api.version>
-        <jaxb-runtime.version>3.0.2</jaxb-runtime.version>
+        <jakarta.xml.soap-api.version>3.0.1</jakarta.xml.soap-api.version>
+        <jaxb-runtime.version>4.0.4</jaxb-runtime.version>
         <kiwi-bom.version>2.0.4</kiwi-bom.version>
     </properties>
 
@@ -73,7 +74,7 @@
     <scm>
         <connection>scm:git:https://github.com/kiwiproject/dropwizard-jakarta-xml-ws.git</connection>
         <developerConnection>scm:git@github.com:kiwiproject/dropwizard-jakarta-xml-ws.git</developerConnection>
-        <url>git@github.com:roskart/dropwizard-jaxws.git</url>
+        <url>https://github.com/kiwiproject/dropwizard-jakarta-xml-ws</url>
     </scm>
 
     <issueManagement>
@@ -101,6 +102,12 @@
                 <groupId>jakarta.transaction</groupId>
                 <artifactId>jakarta.transaction-api</artifactId>
                 <version>${jakarta.transaction-api.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.xml.soap</groupId>
+                <artifactId>jakarta.xml.soap-api</artifactId>
+                <version>${jakarta.xml.soap-api.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
* Fix the url in the scm element in the root POM
* Add jakarta.xml.soap-api to dependency management and lock version to 3.0.1
* Update jaxb-runtime version to 4.0.4 (Jakarta EE 10)
* Update NOTE in the root POM re: Jakarta EE 9 and 10 versions (it's messy)
* Add TODOs re: exclusions in bundle and example POMs
* Add saaj-impl in the example POM so that the examples work, otherwise at runtime we get the following error: "Provider com.sun.xml.messaging.saaj.soap.SAAJMetaFactoryImpl not found"