### PR TITLE
Remove istack-commons-runtime exclusion from POM

### DIFF
--- a/dropwizard-jaxws/pom.xml
+++ b/dropwizard-jaxws/pom.xml
@@ -37,15 +37,6 @@
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
             <version>${cxf.version}</version>
-            <!-- TODO: Can this be removed? -->
-            <exclusions>
-                <!-- jaxb-core 2.2.7 contains classes from istack-commons-runtime 2.16
-                and it also has dependency on istack-commons-runtime 2.16 -->
-                <exclusion>
-                    <groupId>com.sun.istack</groupId>
-                    <artifactId>istack-commons-runtime</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
The tests all still pass, and the example app starts and runs and the HTTP endpoints all work.