### PR TITLE
Sonar cleanup: WsdlFirstClientHandler

### DIFF
--- a/dropwizard-jaxws-example/src/main/java/com/roskart/dropwizard/jaxws/example/resources/WsdlFirstClientHandler.java
+++ b/dropwizard-jaxws-example/src/main/java/com/roskart/dropwizard/jaxws/example/resources/WsdlFirstClientHandler.java
@@ -16,19 +16,21 @@ import java.util.Set;
  */
 public class WsdlFirstClientHandler implements SOAPHandler<SOAPMessageContext> {
 
-    Logger log = LoggerFactory.getLogger(WsdlFirstClientHandler.class);
+    private static final Logger LOG = LoggerFactory.getLogger(WsdlFirstClientHandler.class);
 
     @Override
     public Set<QName> getHeaders() {
-        return null;
+        return Set.of();
     }
 
     @Override
     public void close(MessageContext messageContext) {
+        LOG.info("Closing");
     }
 
     @Override
     public boolean handleFault(SOAPMessageContext context) {
+        LOG.warn("Handling fault");
         return true;
     }
 
@@ -38,9 +40,9 @@ public class WsdlFirstClientHandler implements SOAPHandler<SOAPMessageContext> {
         Boolean outbound = (Boolean) context.get(MessageContext.MESSAGE_OUTBOUND_PROPERTY);
 
         if (Boolean.TRUE.equals(outbound)) {
-            log.info("WsdlFirstService client handler - outbound");
+            LOG.info("WsdlFirstService client handler - outbound");
         } else {
-            log.info("WsdlFirstService client handler - inbound");
+            LOG.info("WsdlFirstService client handler - inbound");
         }
 
         return true;


### PR DESCRIPTION
* Make the Logger static and final; rename to LOG
* Return empty Set from getHeaders instead of null
* Add some logging in close to make Sonar happy
* Also log when we're handling a fault, even though not doing anything