### PR TITLE
Add Nullable annotation in JAXWSBundle

### DIFF
--- a/dropwizard-jakarta-xml-ws/pom.xml
+++ b/dropwizard-jakarta-xml-ws/pom.xml
@@ -14,6 +14,11 @@
     <dependencies>
 
         <dependency>
+            <groupId>org.checkerframework</groupId>
+            <artifactId>checker-qual</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
             <scope>provided</scope>

--- a/dropwizard-jakarta-xml-ws/src/main/java/com/roskart/dropwizard/jaxws/JAXWSBundle.java
+++ b/dropwizard-jakarta-xml-ws/src/main/java/com/roskart/dropwizard/jaxws/JAXWSBundle.java
@@ -7,6 +7,7 @@ import io.dropwizard.core.setup.Bootstrap;
 import io.dropwizard.core.setup.Environment;
 import jakarta.xml.ws.handler.Handler;
 import org.apache.cxf.jaxws.EndpointImpl;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hibernate.SessionFactory;
 
 /**
@@ -187,8 +188,9 @@ public class JAXWSBundle<C> implements ConfiguredBundle<C> {
      * Override this method to configure the bundle.
      *
      * @param configuration Application configuration.
-     * @return Published endpoint URL prefix.
+     * @return Published endpoint URL prefix, or null if there is no prefix
      */
+    @Nullable
     protected String getPublishedEndpointUrlPrefix(C configuration) {
         return null;
     }


### PR DESCRIPTION
Add Checker Nullable annotation to getPublishedEndpointUrlPrefix in JAXWSBundle. This method is intended to be overriden if an application wants to provide a URL prefix.