### PR TITLE
More miscellaneous code cleanup; suppress warnings in test code

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ For the initial [0.5.0](https://github.com/kiwiproject/dropwizard-jakarta-xml-ws
 retain the original package names (`com.roskart.dropwizard.jaxws`).
 
 Release 0.6.0 will remove deprecated code, i.e. the deprecated methods in `JAXWSBundle`. It will also
-rename the modules so they are consistent, i.e. rename `dropwizard-jaxws` to `dropwizard-jakarta-xml-ws`.
+rename the modules so that they are consistent, i.e. rename `dropwizard-jaxws` to `dropwizard-jakarta-xml-ws`.
 
 In some future version, we will rename the packages to use the `org.kiwiproject` prefix and
 then some suffix, e.g. `dropwizard.jakarta.xml.ws` (which matches the actual Jakarta packages which begin

--- a/dropwizard-jakarta-xml-ws-example/src/main/java/com/roskart/dropwizard/jaxws/example/JaxWsExampleApplication.java
+++ b/dropwizard-jakarta-xml-ws-example/src/main/java/com/roskart/dropwizard/jaxws/example/JaxWsExampleApplication.java
@@ -35,7 +35,7 @@ public class JaxWsExampleApplication extends Application<JaxWsExampleApplication
     private static final Logger LOG = LoggerFactory.getLogger(JaxWsExampleApplication.class);
 
     // HibernateBundle is used by HibernateExampleService
-    private final HibernateBundle<JaxWsExampleApplicationConfiguration> hibernate = new HibernateBundle<JaxWsExampleApplicationConfiguration>(Person.class) {
+    private final HibernateBundle<JaxWsExampleApplicationConfiguration> hibernate = new HibernateBundle<>(Person.class) {
         @Override
         public DataSourceFactory getDataSourceFactory(JaxWsExampleApplicationConfiguration configuration) {
             return configuration.getDatabaseConfiguration();
@@ -43,8 +43,8 @@ public class JaxWsExampleApplication extends Application<JaxWsExampleApplication
     };
 
     // Jakarta XML Web Services Bundle
-    private JAXWSBundle<Object> jaxWsBundle = new JAXWSBundle<>();
-    private JAXWSBundle<Object> anotherJaxWsBundle = new JAXWSBundle<>("/api2");
+    private final JAXWSBundle<Object> jaxWsBundle = new JAXWSBundle<>();
+    private final JAXWSBundle<Object> anotherJaxWsBundle = new JAXWSBundle<>("/api2");
 
     public static void main(String[] args) throws Exception {
         new JaxWsExampleApplication().run(args);

--- a/dropwizard-jakarta-xml-ws-example/src/main/java/com/roskart/dropwizard/jaxws/example/ws/JavaFirstServiceImpl.java
+++ b/dropwizard-jakarta-xml-ws-example/src/main/java/com/roskart/dropwizard/jaxws/example/ws/JavaFirstServiceImpl.java
@@ -22,7 +22,7 @@ public class JavaFirstServiceImpl implements JavaFirstService {
     @Metered
     @ExceptionMetered
     public String echo(String in) throws JavaFirstServiceException {
-        if (in == null || in.trim().length() == 0) {
+        if (in == null || in.isBlank()) {
             throw new JavaFirstServiceException("Invalid parameter");
         }
 

--- a/dropwizard-jakarta-xml-ws-example/src/main/java/com/roskart/dropwizard/jaxws/example/ws/WsdlFirstServiceImpl.java
+++ b/dropwizard-jakarta-xml-ws-example/src/main/java/com/roskart/dropwizard/jaxws/example/ws/WsdlFirstServiceImpl.java
@@ -42,21 +42,18 @@ public class WsdlFirstServiceImpl implements WsdlFirstService {
 
         final ServerAsyncResponse<EchoResponse> sar = new ServerAsyncResponse<>();
 
-        new Thread() {
-            @Override
-            public void run() {
-                try {
-                    Thread.sleep(1000);
-                    EchoResponse response = new EchoResponse();
-                    response.setValue("Non-blocking: " + parameters.getValue());
-                    sar.set(response);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    sar.exception(e);
-                }
-                asyncHandler.handleResponse(sar);
+        new Thread(() -> {
+            try {
+                Thread.sleep(1000);
+                EchoResponse response = new EchoResponse();
+                response.setValue("Non-blocking: " + parameters.getValue());
+                sar.set(response);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                sar.exception(e);
             }
-        }.start();
+            asyncHandler.handleResponse(sar);
+        }).start();
 
         return sar;
     }

--- a/dropwizard-jakarta-xml-ws/src/main/java/com/roskart/dropwizard/jaxws/UnitOfWorkInvoker.java
+++ b/dropwizard-jakarta-xml-ws/src/main/java/com/roskart/dropwizard/jaxws/UnitOfWorkInvoker.java
@@ -66,6 +66,7 @@ public class UnitOfWorkInvoker extends AbstractInvoker {
     /**
      * @see io.dropwizard.hibernate.UnitOfWorkAspect#beginTransaction(UnitOfWork, Session)
      */
+    @SuppressWarnings("JavadocReference")
     private void beginTransaction(Session session, UnitOfWork unitOfWork) {
         if (unitOfWork.transactional()) {
             session.beginTransaction();
@@ -75,6 +76,7 @@ public class UnitOfWorkInvoker extends AbstractInvoker {
     /**
      * @see io.dropwizard.hibernate.UnitOfWorkAspect#configureSession()
      */
+    @SuppressWarnings("JavadocReference")
     private void configureSession(Session session, UnitOfWork unitOfWork) {
         session.setDefaultReadOnly(unitOfWork.readOnly());
         session.setCacheMode(unitOfWork.cacheMode());
@@ -84,6 +86,7 @@ public class UnitOfWorkInvoker extends AbstractInvoker {
     /**
      * @see io.dropwizard.hibernate.UnitOfWorkAspect#rollbackTransaction(UnitOfWork, Session)
      */
+    @SuppressWarnings("JavadocReference")
     private void rollbackTransaction(Session session, UnitOfWork unitOfWork) {
         if (unitOfWork.transactional()) {
             final Transaction txn = session.getTransaction();
@@ -96,6 +99,7 @@ public class UnitOfWorkInvoker extends AbstractInvoker {
     /**
      * @see io.dropwizard.hibernate.UnitOfWorkAspect#commitTransaction(UnitOfWork, Session)
      */
+    @SuppressWarnings("JavadocReference")
     private void commitTransaction(Session session, UnitOfWork unitOfWork) {
         if (unitOfWork.transactional()) {
             final Transaction txn = session.getTransaction();

--- a/dropwizard-jakarta-xml-ws/src/test/java/com/roskart/dropwizard/jaxws/DummyService.java
+++ b/dropwizard-jakarta-xml-ws/src/test/java/com/roskart/dropwizard/jaxws/DummyService.java
@@ -6,6 +6,7 @@ import jakarta.jws.WebService;
 @WebService
 public class DummyService {
 
+    @SuppressWarnings("EmptyMethod")
     @WebMethod
     public void foo() {
     }

--- a/dropwizard-jakarta-xml-ws/src/test/java/com/roskart/dropwizard/jaxws/ValidatingInvokerTest.java
+++ b/dropwizard-jakarta-xml-ws/src/test/java/com/roskart/dropwizard/jaxws/ValidatingInvokerTest.java
@@ -46,6 +46,7 @@ class ValidatingInvokerTest {
         }
     }
 
+    @SuppressWarnings("all")
     static class RootParam1 {
         @Valid
         private final ChildParam child;
@@ -55,6 +56,7 @@ class ValidatingInvokerTest {
         }
     }
 
+    @SuppressWarnings("all")
     static class RootParam2 {
         @NotEmpty
         private final String foo;
@@ -64,7 +66,7 @@ class ValidatingInvokerTest {
         }
     }
 
-    @SuppressWarnings("unused")
+    @SuppressWarnings("all")
     static class DummyService {
         public void noParams() {
         }


### PR DESCRIPTION
* Suppress javadoc reference problems in UnitOfWorkInvoker; the methods are private, and IDEs (at least IntelliJ) lets you click through to the non-public methods in the "see" references
* Suppress "empty method" warning in DummyService
* Suppress all warnings on the test classes inside ValidatingInvokerTest
* Simplify: use isBlank() in JavaFirstServiceImpl instead of the more verbose: trim(0.length() == 0
* Java 8: use a lambda instead of anonymous inner class in WsdlFirstServiceImpl
* Make instance fields final in JaxWsExampleApplication
* Use <> operator in JaxWsExampleApplication when type can be inferred
* Fix minor grammar error in README