### PR TITLE
Change value of BasicAuthenticationInterceptor.PRINCIPAL_KEY

### DIFF
--- a/dropwizard-jakarta-xml-ws-example/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/example/resources/AccessMtomServiceResource.java
+++ b/dropwizard-jakarta-xml-ws-example/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/example/resources/AccessMtomServiceResource.java
@@ -15,6 +15,7 @@ import ws.example.ws.xml.jakarta.dropwizard.kiwiproject.org.mtomservice.ObjectFa
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.time.LocalDateTime;
 
 @Path("/mtomclient")
 @Produces(MediaType.APPLICATION_JSON)
@@ -39,7 +40,8 @@ public class AccessMtomServiceResource {
 
         try {
             return "Hello response: " + hr.getTitle() + ", " +
-                    IOUtils.readStringFromStream(hr.getBinary().getInputStream());
+                    IOUtils.readStringFromStream(hr.getBinary().getInputStream()) +
+                    " at " + LocalDateTime.now();
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/dropwizard-jakarta-xml-ws-example/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/example/resources/AccessWsdlFirstServiceResource.java
+++ b/dropwizard-jakarta-xml-ws-example/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/example/resources/AccessWsdlFirstServiceResource.java
@@ -10,6 +10,8 @@ import ws.example.ws.xml.jakarta.dropwizard.kiwiproject.org.wsdlfirstservice.Ech
 import ws.example.ws.xml.jakarta.dropwizard.kiwiproject.org.wsdlfirstservice.ObjectFactory;
 import ws.example.ws.xml.jakarta.dropwizard.kiwiproject.org.wsdlfirstservice.WsdlFirstService;
 
+import java.time.LocalDateTime;
+
 /**
  * A Dropwizard resource that invokes WsdlFirstService SOAP web service.
  *
@@ -35,6 +37,6 @@ public class AccessWsdlFirstServiceResource {
 
         EchoResponse er = wsdlFirstServiceClient.echo(e);
 
-        return "Echo response: " + er.getValue();
+        return "Echo response: " + er.getValue() + " at " + LocalDateTime.now();
     }
 }

--- a/dropwizard-jakarta-xml-ws-example/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/example/ws/JavaFirstServiceImpl.java
+++ b/dropwizard-jakarta-xml-ws-example/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/example/ws/JavaFirstServiceImpl.java
@@ -7,6 +7,7 @@ import jakarta.jws.WebService;
 import jakarta.xml.ws.WebServiceContext;
 
 import java.security.Principal;
+import java.time.LocalDateTime;
 
 @WebService(name = "JavaFirstService",
         serviceName = "JavaFirstService",
@@ -26,7 +27,7 @@ public class JavaFirstServiceImpl implements JavaFirstService {
             throw new JavaFirstServiceException("Invalid parameter");
         }
 
-        Principal user = (Principal) wsContext.getMessageContext().get("dropwizard.jaxws.principal");
-        return in + "; principal: " + user.getName();
+        Principal user = (Principal) wsContext.getMessageContext().get("dropwizard.jakarta.xml.ws.principal");
+        return in + "; principal: " + user.getName() + " at " + LocalDateTime.now();
     }
 }

--- a/dropwizard-jakarta-xml-ws/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/BasicAuthenticationInterceptor.java
+++ b/dropwizard-jakarta-xml-ws/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/BasicAuthenticationInterceptor.java
@@ -37,7 +37,7 @@ public class BasicAuthenticationInterceptor extends AbstractPhaseInterceptor<Mes
 
     private static final Logger LOG = LoggerFactory.getLogger(BasicAuthenticationInterceptor.class);
 
-    public static final String PRINCIPAL_KEY = "dropwizard.jaxws.principal";
+    public static final String PRINCIPAL_KEY = "dropwizard.jakarta.xml.ws.principal";
 
     private BasicAuthentication authentication;
 


### PR DESCRIPTION
This is a breaking change for applications that are using this library with basic authentication. The change needed in those applications is to change the key requested from the message context to the new value of PRINCIPAL_KEY, which is now "dropwizard.jakarta.xml.ws.principal"

Also, added the current date/time in the output of JavaFirstServiceImpl and the two HTTP resource classes, so that it is clear that new requests are being made, e.g. in a browser

Closes #74