### PR TITLE
Rename application and configuration classes in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,16 +110,16 @@ public HelloWorldSOAP {
 ```java
 public class MyApplication extends Application<MyApplicationConfiguration> {
 
-    private JAXWSBundle jaxWsBundle = new JAXWSBundle();
+  private JAXWSBundle jswBundle = new JAXWSBundle();
 
     @Override
     public void initialize(Bootstrap<MyApplicationConfiguration> bootstrap) {
-        bootstrap.addBundle(jaxWsBundle);
+      bootstrap.addBundle(jswBundle);
     }
 
     @Override
     public void run(MyApplicationConfiguration configuration, Environment environment) throws Exception {
-        jaxWsBundle.publishEndpoint(
+      jswBundle.publishEndpoint(
             new EndpointBuilder("/hello", new HelloWorldSOAP()));
     }
 
@@ -135,7 +135,7 @@ Client
 Using HelloWorldSOAP web service client:
 
 ```java
-HelloWorldSOAP helloWorld = jaxWsBundle.getClient(
+HelloWorldSOAP helloWorld=jwsBundle.getClient(
     new ClientBuilder(HelloWorldSOAP.class, "http://server/path"));
 System.out.println(helloWorld.sayHello());
 ```

--- a/dropwizard-jakarta-xml-ws-example/pom.xml
+++ b/dropwizard-jakarta-xml-ws-example/pom.xml
@@ -130,7 +130,7 @@
                                         <transformers>
                                             <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
                                             <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                                <mainClass>org.kiwiproject.dropwizard.jakarta.xml.ws.example.JaxWsExampleApplication</mainClass>
+                                                <mainClass>org.kiwiproject.dropwizard.jakarta.xml.ws.example.JakartaXmlWsExampleApplication</mainClass>
                                             </transformer>
                                             <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                                                 <resource>META-INF/cxf/bus-extensions.txt</resource>

--- a/dropwizard-jakarta-xml-ws-example/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/example/JakartaXmlWsExampleConfiguration.java
+++ b/dropwizard-jakarta-xml-ws-example/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/example/JakartaXmlWsExampleConfiguration.java
@@ -6,7 +6,7 @@ import io.dropwizard.db.DataSourceFactory;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
-public class JaxWsExampleApplicationConfiguration extends Configuration {
+public class JakartaXmlWsExampleConfiguration extends Configuration {
 
     @Valid
     @NotNull


### PR DESCRIPTION
* Rename JaxWsExampleApplication to JakartaXmlWsExampleApplication
* Rename JaxWsExampleApplicationConfiguration to JakartaXmlWsExampleConfiguration
* Rename the JAXWSBundle fields in JakartaXmlWsExampleApplication to have the "jws" prefix instead of "jaxWs"
* Update the example in the README to use a field name of jwsBundle instead of jaxWsBundle

Closes #79