### PR TITLE
Rename bundle and environment classes (breaking API change)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ public HelloWorldSOAP {
 ```java
 public class MyApplication extends Application<MyApplicationConfiguration> {
 
-  private JAXWSBundle jswBundle = new JAXWSBundle();
+  private JakartaXmlWsBundle<MyApplicationConfiguration> jswBundle = new JakartaXmlWsBundle<>();
 
     @Override
     public void initialize(Bootstrap<MyApplicationConfiguration> bootstrap) {
@@ -142,7 +142,8 @@ System.out.println(helloWorld.sayHello());
 
 Examples
 --------
-Module `dropwizard-jakarta-xml-ws-example` contains Dropwizard application (`JaxWsExampleApplication`) with the following SOAP
+Module `dropwizard-jakarta-xml-ws-example` contains Dropwizard application (`JakartaXmlWsExampleApplication`) with the
+following SOAP
 web services and RESTful resources:
 
 * **SimpleService**: A minimal 'hello world' example.
@@ -175,7 +176,8 @@ Jakarta XML Web Services handler.
 * **AccessMtomServiceResource**: Dropwizard RESTful service which uses `MtomService` client to invoke
 `MtomService` SOAP web service on the same host as an example for client side MTOM support.
 
-* See `JaxWsExampleApplication` for examples on usage of client side Jakarta XML Web Services handler and CXF interceptors.
+* See `JakartaXmlWsExampleApplication` for examples on usage of client side Jakarta XML Web Services handler and CXF
+  interceptors.
 
 ### Running the examples:
 

--- a/dropwizard-jakarta-xml-ws-example/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/example/JakartaXmlWsExampleApplication.java
+++ b/dropwizard-jakarta-xml-ws-example/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/example/JakartaXmlWsExampleApplication.java
@@ -11,7 +11,7 @@ import org.apache.cxf.jaxws.EndpointImpl;
 import org.kiwiproject.dropwizard.jakarta.xml.ws.BasicAuthentication;
 import org.kiwiproject.dropwizard.jakarta.xml.ws.ClientBuilder;
 import org.kiwiproject.dropwizard.jakarta.xml.ws.EndpointBuilder;
-import org.kiwiproject.dropwizard.jakarta.xml.ws.JAXWSBundle;
+import org.kiwiproject.dropwizard.jakarta.xml.ws.JakartaXmlWsBundle;
 import org.kiwiproject.dropwizard.jakarta.xml.ws.example.auth.BasicAuthenticator;
 import org.kiwiproject.dropwizard.jakarta.xml.ws.example.core.Person;
 import org.kiwiproject.dropwizard.jakarta.xml.ws.example.db.PersonDAO;
@@ -43,8 +43,8 @@ public class JakartaXmlWsExampleApplication extends Application<JakartaXmlWsExam
     };
 
     // Jakarta XML Web Services Bundle
-    private final JAXWSBundle<Object> jwsBundle = new JAXWSBundle<>();
-    private final JAXWSBundle<Object> anotherJwsBundle = new JAXWSBundle<>("/api2");
+    private final JakartaXmlWsBundle<JakartaXmlWsExampleConfiguration> jwsBundle = new JakartaXmlWsBundle<>();
+    private final JakartaXmlWsBundle<JakartaXmlWsExampleConfiguration> anotherJwsBundle = new JakartaXmlWsBundle<>("/api2");
 
     public static void main(String[] args) throws Exception {
         new JakartaXmlWsExampleApplication().run(args);
@@ -69,7 +69,7 @@ public class JakartaXmlWsExampleApplication extends Application<JakartaXmlWsExam
         // publishEndpoint returns javax.xml.ws.Endpoint to enable further customization.
         // e.getProperties().put(...);
 
-        // Publish Hello world service again using different JAXWSBundle instance
+        // Publish Hello world service again using different JakartaXmlWsBundle instance
         e = anotherJwsBundle.publishEndpoint(
                 new EndpointBuilder("/simple", new SimpleService()));
 
@@ -93,7 +93,7 @@ public class JakartaXmlWsExampleApplication extends Application<JakartaXmlWsExam
                         new HibernateExampleService(personDAO))
                         .sessionFactory(hibernate.getSessionFactory()));
 
-        // Publish the same service again using different JAXWSBundle instance
+        // Publish the same service again using different JakartaXmlWsBundle instance
         e = anotherJwsBundle.publishEndpoint(
                 new EndpointBuilder("/hibernate",
                         new HibernateExampleService(personDAO))

--- a/dropwizard-jakarta-xml-ws/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/JakartaXmlWsBundle.java
+++ b/dropwizard-jakarta-xml-ws/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/JakartaXmlWsBundle.java
@@ -12,16 +12,16 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * A Dropwizard bundle that enables Dropwizard applications to publish SOAP web services using
  * Jakarta XML Web Services and to create web service clients.
  */
-public class JAXWSBundle<C> implements ConfiguredBundle<C> {
+public class JakartaXmlWsBundle<C> implements ConfiguredBundle<C> {
 
     protected static final String DEFAULT_PATH = "/soap";
-    protected final JAXWSEnvironment jwsEnvironment;
+    protected final JakartaXmlWsEnvironment jwsEnvironment;
     protected final String servletPath;
 
     /**
      * Create a new bundle instance. Service endpoints are published relative to '/soap'.
      */
-    public JAXWSBundle() {
+    public JakartaXmlWsBundle() {
         this(DEFAULT_PATH);
     }
 
@@ -30,18 +30,18 @@ public class JAXWSBundle<C> implements ConfiguredBundle<C> {
      *
      * @param servletPath Root path for service endpoints. Leading slash is required.
      */
-    public JAXWSBundle(String servletPath) {
-        this(servletPath, new JAXWSEnvironment(servletPath));
+    public JakartaXmlWsBundle(String servletPath) {
+        this(servletPath, new JakartaXmlWsEnvironment(servletPath));
     }
 
     /**
-     * Create a new bundle instance using the provided JAXWSEnvironment. Service endpoints are
+     * Create a new bundle instance using the provided JakartaXmlWsEnvironment. Service endpoints are
      * published relative to the provided servletPath.
      *
      * @param servletPath    Root path for service endpoints. Leading slash is required.
-     * @param jwsEnvironment Valid JAXWSEnvironment.
+     * @param jwsEnvironment Valid JakartaXmlWsEnvironment.
      */
-    public JAXWSBundle(String servletPath, JAXWSEnvironment jwsEnvironment) {
+    public JakartaXmlWsBundle(String servletPath, JakartaXmlWsEnvironment jwsEnvironment) {
         checkArgument(servletPath != null, "Servlet path is null");
         checkArgument(servletPath.startsWith("/"), "%s is not an absolute path", servletPath);
         checkArgument(jwsEnvironment != null, "jwsEnvironment is null");

--- a/dropwizard-jakarta-xml-ws/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/JakartaXmlWsEnvironment.java
+++ b/dropwizard-jakarta-xml-ws/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/JakartaXmlWsEnvironment.java
@@ -27,9 +27,9 @@ import org.slf4j.LoggerFactory;
  * Performs CXF Bus setup and provides methods for publishing Jakarta XML Web Services endpoints and creating
  * Jakarta XML Web Services clients.
  */
-public class JAXWSEnvironment {
+public class JakartaXmlWsEnvironment {
 
-    private static final Logger LOG = LoggerFactory.getLogger(JAXWSEnvironment.class);
+    private static final Logger LOG = LoggerFactory.getLogger(JakartaXmlWsEnvironment.class);
 
     protected final Bus bus;
     protected final String defaultPath;
@@ -41,7 +41,7 @@ public class JAXWSEnvironment {
         return this.defaultPath;
     }
 
-    public JAXWSEnvironment(String defaultPath) {
+    public JakartaXmlWsEnvironment(String defaultPath) {
 
         System.setProperty("org.apache.cxf.Logger", "org.apache.cxf.common.logging.Slf4jLogger");
         /*

--- a/dropwizard-jakarta-xml-ws/src/test/java/org/kiwiproject/dropwizard/jakarta/xml/ws/JakartaXmlWsBundleTest.java
+++ b/dropwizard-jakarta-xml-ws/src/test/java/org/kiwiproject/dropwizard/jakarta/xml/ws/JakartaXmlWsBundleTest.java
@@ -23,13 +23,13 @@ import jakarta.servlet.http.HttpServlet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class JAXWSBundleTest {
+class JakartaXmlWsBundleTest {
 
     Environment environment;
     Bootstrap<?> bootstrap;
     ServletEnvironment servletEnvironment;
     ServletRegistration.Dynamic servlet;
-    JAXWSEnvironment jwsEnvironment;
+    JakartaXmlWsEnvironment jwsEnvironment;
     LifecycleEnvironment lifecycleEnvironment;
 
     @BeforeEach
@@ -38,7 +38,7 @@ class JAXWSBundleTest {
         bootstrap = mock(Bootstrap.class);
         servletEnvironment = mock(ServletEnvironment.class);
         servlet = mock(ServletRegistration.Dynamic.class);
-        jwsEnvironment = mock(JAXWSEnvironment.class);
+        jwsEnvironment = mock(JakartaXmlWsEnvironment.class);
         lifecycleEnvironment = mock(LifecycleEnvironment.class);
 
         when(environment.servlets()).thenReturn(servletEnvironment);
@@ -52,24 +52,24 @@ class JAXWSBundleTest {
     @Test
     void constructorArgumentChecks() {
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> new JAXWSBundle<>(null, jwsEnvironment))
+                .isThrownBy(() -> new JakartaXmlWsBundle<>(null, jwsEnvironment))
                 .withMessage("Servlet path is null");
 
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> new JAXWSBundle<>("soap", jwsEnvironment))
+                .isThrownBy(() -> new JakartaXmlWsBundle<>("soap", jwsEnvironment))
                 .withMessage("soap is not an absolute path");
 
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> new JAXWSBundle<>("/soap", null))
+                .isThrownBy(() -> new JakartaXmlWsBundle<>("/soap", null))
                 .withMessage("jwsEnvironment is null");
 
-        assertThatCode(() -> new JAXWSBundle<>("/soap", jwsEnvironment))
+        assertThatCode(() -> new JakartaXmlWsBundle<>("/soap", jwsEnvironment))
                 .doesNotThrowAnyException();
     }
 
     @Test
     void initializeAndRun() {
-        JAXWSBundle<?> jwsBundle = new JAXWSBundle<>("/soap", jwsEnvironment);
+        JakartaXmlWsBundle<?> jwsBundle = new JakartaXmlWsBundle<>("/soap", jwsEnvironment);
 
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> jwsBundle.run(null, null))
@@ -87,7 +87,7 @@ class JAXWSBundleTest {
 
     @Test
     void initializeAndRunWithPublishedEndpointUrlPrefix() {
-        JAXWSBundle<?> jwsBundle = new JAXWSBundle<Configuration>("/soap", jwsEnvironment) {
+        JakartaXmlWsBundle<?> jwsBundle = new JakartaXmlWsBundle<Configuration>("/soap", jwsEnvironment) {
             @Override
             protected String getPublishedEndpointUrlPrefix(Configuration configuration) {
                 return "http://some/prefix";
@@ -111,7 +111,7 @@ class JAXWSBundleTest {
     @Test
     void publishEndpoint() {
 
-        JAXWSBundle<?> jwsBundle = new JAXWSBundle<>("/soap", jwsEnvironment);
+        JakartaXmlWsBundle<?> jwsBundle = new JakartaXmlWsBundle<>("/soap", jwsEnvironment);
         Object service = new Object();
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> jwsBundle.publishEndpoint(new EndpointBuilder("foo", null)))
@@ -133,7 +133,7 @@ class JAXWSBundleTest {
     @Test
     void getClient() {
 
-        JAXWSBundle<?> jwsBundle = new JAXWSBundle<>("/soap", jwsEnvironment);
+        JakartaXmlWsBundle<?> jwsBundle = new JakartaXmlWsBundle<>("/soap", jwsEnvironment);
 
         Class<?> cls = Object.class;
         String url = "http://foo";

--- a/dropwizard-jakarta-xml-ws/src/test/java/org/kiwiproject/dropwizard/jakarta/xml/ws/JakartaXmlWsEnvironmentTest.java
+++ b/dropwizard-jakarta-xml-ws/src/test/java/org/kiwiproject/dropwizard/jakarta/xml/ws/JakartaXmlWsEnvironmentTest.java
@@ -48,11 +48,11 @@ import javax.wsdl.WSDLException;
 import java.lang.reflect.Proxy;
 import java.util.HashMap;
 
-class JAXWSEnvironmentTest {
+class JakartaXmlWsEnvironmentTest {
 
     private static final String SOAP_REQUEST_FILE_NAME = "test-soap-request.xml";
 
-    private JAXWSEnvironment jwsEnvironment;
+    private JakartaXmlWsEnvironment jwsEnvironment;
     private Invoker mockInvoker;
     private TestUtilities testutils;
     private DummyService service;
@@ -93,12 +93,12 @@ class JAXWSEnvironmentTest {
         ((ch.qos.logback.classic.Logger) LoggerFactory.getLogger("org.apache.cxf")).setLevel(Level.INFO);
 
         mockInvoker = mock(Invoker.class);
-        testutils = new TestUtilities(JAXWSEnvironmentTest.class);
+        testutils = new TestUtilities(JakartaXmlWsEnvironmentTest.class);
         service = new DummyService();
         mockInvokerBuilder = mock(InstrumentedInvokerFactory.class);
         mockUnitOfWorkInvokerBuilder = mock(UnitOfWorkInvokerFactory.class);
 
-        jwsEnvironment = new JAXWSEnvironment("soap") {
+        jwsEnvironment = new JakartaXmlWsEnvironment("soap") {
             /*
             We create BasicAuthenticationInterceptor mock manually, because Mockito provided mock
             does not get invoked by CXF
@@ -162,13 +162,13 @@ class JAXWSEnvironmentTest {
     void publishEndpointWithAnotherEnvironment() throws Exception {
 
         // creating new runtime environment simulates using separate bundles
-        JAXWSEnvironment anotherJaxwsEnvironment = new JAXWSEnvironment("soap2");
-        anotherJaxwsEnvironment.setInstrumentedInvokerBuilder(mockInvokerBuilder);
-        anotherJaxwsEnvironment.setUnitOfWorkInvokerBuilder(mockUnitOfWorkInvokerBuilder);
+        var anotherJwsEnvironment = new JakartaXmlWsEnvironment("soap2");
+        anotherJwsEnvironment.setInstrumentedInvokerBuilder(mockInvokerBuilder);
+        anotherJwsEnvironment.setUnitOfWorkInvokerBuilder(mockUnitOfWorkInvokerBuilder);
 
-        testutils.setBus(anotherJaxwsEnvironment.bus);
+        testutils.setBus(anotherJwsEnvironment.bus);
 
-        anotherJaxwsEnvironment.publishEndpoint(new EndpointBuilder("local://path", service));
+        anotherJwsEnvironment.publishEndpoint(new EndpointBuilder("local://path", service));
 
         verify(mockInvokerBuilder).create(any(), any(Invoker.class));
         verifyNoInteractions(mockUnitOfWorkInvokerBuilder);


### PR DESCRIPTION
* Rename JAXWSBundle to JakartaXmlWsBundle
* Rename JAXWSEnvironment to JakartaXmlWsEnvironment
* Change fields in JakartaXmlWsExampleApplication so that they are parameterized by JakartaXmlWsExampleConfiguration instead of Object
* Update example code in the README to reflect bundle name change, and also make it use generics

Closes #81