### PR TITLE
Code cleanup: UnitOfWorkInvoker and UnitOfWorkInvokerFactory

### DIFF
--- a/dropwizard-jakarta-xml-ws/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/UnitOfWorkInvokerFactory.java
+++ b/dropwizard-jakarta-xml-ws/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/UnitOfWorkInvokerFactory.java
@@ -14,8 +14,7 @@ public class UnitOfWorkInvokerFactory {
      */
     public Invoker create(Object service, Invoker rootInvoker, SessionFactory sessionFactory) {
 
-        ImmutableMap.Builder<String, UnitOfWork> unitOfWorkMethodsBuilder =
-                new ImmutableMap.Builder<>();
+        var unitOfWorkMethodsBuilder = new ImmutableMap.Builder<String, UnitOfWork>();
 
         for (Method m : service.getClass().getMethods()) {
             if (m.isAnnotationPresent(UnitOfWork.class)) {
@@ -24,13 +23,11 @@ public class UnitOfWorkInvokerFactory {
         }
         ImmutableMap<String, UnitOfWork> unitOfWorkMethods = unitOfWorkMethodsBuilder.build();
 
-        Invoker invoker = rootInvoker;
-
-        if (!unitOfWorkMethods.isEmpty()) {
-            invoker = new UnitOfWorkInvoker(invoker, unitOfWorkMethods, sessionFactory);
+        if (unitOfWorkMethods.isEmpty()) {
+            return rootInvoker;
         }
 
-        return invoker;
+        return new UnitOfWorkInvoker(rootInvoker, unitOfWorkMethods, sessionFactory);
     }
 
 }


### PR DESCRIPTION
* Update obsolete javadoc comment in UnitOfWorkInvoker. Dropwizard made UnitOfWorkAspect public a long time ago, in version 1.1.0.
* Modify UnitOfWorkInvoker#invoke to use try-with-resources for the Hibernate Session, and wrap the Map#get call with requireNonNull since the containsKey check returned true. Remove redundant RuntimeException type parameter in call to rethrow.
* Use var in UnitOfWorkInvokerFactory for the ImmutableMap.Builder to reduce code verbosity
* Refactor logic in UnitOfWorkInvokerFactory so that it doesn't reassign a local variable. Instead, if the "unitOfWorkMethods" map is empty, return the rootInvoker. This inverts the logic and is clearer, since re-assigning variables is generally not a good practice.