### PR TITLE
Opinionated code cleanup: use LVTI

### DIFF
--- a/dropwizard-jakarta-xml-ws-example/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/example/JakartaXmlWsExampleApplication.java
+++ b/dropwizard-jakarta-xml-ws-example/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/example/JakartaXmlWsExampleApplication.java
@@ -7,7 +7,6 @@ import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.hibernate.HibernateBundle;
 import org.apache.cxf.ext.logging.LoggingInInterceptor;
 import org.apache.cxf.ext.logging.LoggingOutInterceptor;
-import org.apache.cxf.jaxws.EndpointImpl;
 import org.kiwiproject.dropwizard.jakarta.xml.ws.BasicAuthentication;
 import org.kiwiproject.dropwizard.jakarta.xml.ws.ClientBuilder;
 import org.kiwiproject.dropwizard.jakarta.xml.ws.EndpointBuilder;
@@ -63,45 +62,45 @@ public class JakartaXmlWsExampleApplication extends Application<JakartaXmlWsExam
 
         // Hello world service
         @SuppressWarnings("unused")
-        EndpointImpl e = jwsBundle.publishEndpoint(
+        var endpoint = jwsBundle.publishEndpoint(
                 new EndpointBuilder("/simple", new SimpleService()));
 
         // publishEndpoint returns javax.xml.ws.Endpoint to enable further customization.
         // e.getProperties().put(...);
 
         // Publish Hello world service again using different JakartaXmlWsBundle instance
-        e = anotherJwsBundle.publishEndpoint(
+        endpoint = anotherJwsBundle.publishEndpoint(
                 new EndpointBuilder("/simple", new SimpleService()));
 
         // Java first service protected with basic authentication
-        e = jwsBundle.publishEndpoint(
+        endpoint = jwsBundle.publishEndpoint(
                 new EndpointBuilder("/javafirst", new JavaFirstServiceImpl())
                         .authentication(new BasicAuthentication(new BasicAuthenticator(), "TOP_SECRET")));
 
         // WSDL first service using server side Jakarta XML Web Services handler and CXF logging interceptors.
         // The server handler is defined in the wsdlfirstservice-handlerchain.xml file, via the
         // HandlerChain annotation on WsdlFirstServiceImpl
-        e = jwsBundle.publishEndpoint(
+        endpoint = jwsBundle.publishEndpoint(
                 new EndpointBuilder("/wsdlfirst", new WsdlFirstServiceImpl())
                         .cxfInInterceptors(new LoggingInInterceptor())
                         .cxfOutInterceptors(new LoggingOutInterceptor()));
 
         // Service using Hibernate
-        PersonDAO personDAO = new PersonDAO(hibernate.getSessionFactory());
-        e = jwsBundle.publishEndpoint(
+        var personDAO = new PersonDAO(hibernate.getSessionFactory());
+        endpoint = jwsBundle.publishEndpoint(
                 new EndpointBuilder("/hibernate",
                         new HibernateExampleService(personDAO))
                         .sessionFactory(hibernate.getSessionFactory()));
 
         // Publish the same service again using different JakartaXmlWsBundle instance
-        e = anotherJwsBundle.publishEndpoint(
+        endpoint = anotherJwsBundle.publishEndpoint(
                 new EndpointBuilder("/hibernate",
                         new HibernateExampleService(personDAO))
                         .sessionFactory(hibernate.getSessionFactory()));
 
         // WSDL first service using MTOM. Invoking enableMTOM on EndpointBuilder is not necessary
         // if you use @MTOM Jakarta XML Web Services annotation on your service implementation class.
-        e = jwsBundle.publishEndpoint(
+        endpoint = jwsBundle.publishEndpoint(
                 new EndpointBuilder("/mtom", new MtomServiceImpl())
                         .enableMtom()
         );

--- a/dropwizard-jakarta-xml-ws-example/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/example/db/PersonDAO.java
+++ b/dropwizard-jakarta-xml-ws-example/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/example/db/PersonDAO.java
@@ -1,7 +1,6 @@
 package org.kiwiproject.dropwizard.jakarta.xml.ws.example.db;
 
 import io.dropwizard.hibernate.AbstractDAO;
-import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.query.Query;
 import org.kiwiproject.dropwizard.jakarta.xml.ws.example.core.Person;
@@ -19,15 +18,15 @@ public class PersonDAO extends AbstractDAO<Person> {
 
         // set up embedded database
 
-        Session sess = sessionFactory.openSession();
+        var session = sessionFactory.openSession();
         try {
-            sess.beginTransaction();
-            sess.createNativeQuery("create table people(id bigint primary key auto_increment not null, " +
+            session.beginTransaction();
+            session.createNativeQuery("create table people(id bigint primary key auto_increment not null, " +
                     "fullname varchar(256) not null, jobtitle varchar(256) not null);", Void.class).executeUpdate();
-            sess.createNativeQuery("create sequence hibernate_sequence", Void.class).executeUpdate();
+            session.createNativeQuery("create sequence hibernate_sequence", Void.class).executeUpdate();
         } finally {
-            sess.getTransaction().commit();
-            sess.close();
+            session.getTransaction().commit();
+            session.close();
         }
     }
 
@@ -41,7 +40,7 @@ public class PersonDAO extends AbstractDAO<Person> {
 
     public List<Person> findAll() {
         @SuppressWarnings("unchecked")
-        Query<Person> query =
+        var query =
                 (Query<Person>) namedQuery("org.kiwiproject.dropwizard.jakarta.xml.ws.example.core.Person.findAll");
         return list(query);
     }

--- a/dropwizard-jakarta-xml-ws-example/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/example/resources/AccessMtomServiceResource.java
+++ b/dropwizard-jakarta-xml-ws-example/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/example/resources/AccessMtomServiceResource.java
@@ -8,8 +8,6 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import org.apache.cxf.helpers.IOUtils;
-import ws.example.ws.xml.jakarta.dropwizard.kiwiproject.org.mtomservice.Hello;
-import ws.example.ws.xml.jakarta.dropwizard.kiwiproject.org.mtomservice.HelloResponse;
 import ws.example.ws.xml.jakarta.dropwizard.kiwiproject.org.mtomservice.MtomService;
 import ws.example.ws.xml.jakarta.dropwizard.kiwiproject.org.mtomservice.ObjectFactory;
 
@@ -31,16 +29,16 @@ public class AccessMtomServiceResource {
     @Timed
     public String getFoo() {
 
-        ObjectFactory of = new ObjectFactory();
-        Hello h = of.createHello();
-        h.setTitle("Hello");
-        h.setBinary(new DataHandler(new ByteArrayDataSource("test".getBytes(), "text/plain")));
+        var objectFactory = new ObjectFactory();
+        var hello = objectFactory.createHello();
+        hello.setTitle("Hello");
+        hello.setBinary(new DataHandler(new ByteArrayDataSource("test".getBytes(), "text/plain")));
 
-        HelloResponse hr = mtomServiceClient.hello(h);
+        var helloResponse = mtomServiceClient.hello(hello);
 
         try {
-            return "Hello response: " + hr.getTitle() + ", " +
-                    IOUtils.readStringFromStream(hr.getBinary().getInputStream()) +
+            return "Hello response: " + helloResponse.getTitle() + ", " +
+                    IOUtils.readStringFromStream(helloResponse.getBinary().getInputStream()) +
                     " at " + LocalDateTime.now();
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/dropwizard-jakarta-xml-ws-example/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/example/resources/AccessProtectedServiceResource.java
+++ b/dropwizard-jakarta-xml-ws-example/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/example/resources/AccessProtectedServiceResource.java
@@ -25,10 +25,9 @@ public class AccessProtectedServiceResource {
     @GET
     public String getEcho() {
         try {
-
-            BindingProvider bp = (BindingProvider) javaFirstService;
-            bp.getRequestContext().put(BindingProvider.USERNAME_PROPERTY, "johndoe");
-            bp.getRequestContext().put(BindingProvider.PASSWORD_PROPERTY, "secret");
+            var bindingProvider = (BindingProvider) javaFirstService;
+            bindingProvider.getRequestContext().put(BindingProvider.USERNAME_PROPERTY, "johndoe");
+            bindingProvider.getRequestContext().put(BindingProvider.PASSWORD_PROPERTY, "secret");
 
             return this.javaFirstService.echo("Hello from the protected service!");
         } catch (JavaFirstService.JavaFirstServiceException jfse) {

--- a/dropwizard-jakarta-xml-ws-example/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/example/resources/AccessWsdlFirstServiceResource.java
+++ b/dropwizard-jakarta-xml-ws-example/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/example/resources/AccessWsdlFirstServiceResource.java
@@ -5,8 +5,6 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
-import ws.example.ws.xml.jakarta.dropwizard.kiwiproject.org.wsdlfirstservice.Echo;
-import ws.example.ws.xml.jakarta.dropwizard.kiwiproject.org.wsdlfirstservice.EchoResponse;
 import ws.example.ws.xml.jakarta.dropwizard.kiwiproject.org.wsdlfirstservice.ObjectFactory;
 import ws.example.ws.xml.jakarta.dropwizard.kiwiproject.org.wsdlfirstservice.WsdlFirstService;
 
@@ -30,13 +28,12 @@ public class AccessWsdlFirstServiceResource {
     @GET
     @Timed
     public String getFoo() {
+        var objectFactory = new ObjectFactory();
+        var echo = objectFactory.createEcho();
+        echo.setValue("echo value");
 
-        ObjectFactory of = new ObjectFactory();
-        Echo e = of.createEcho();
-        e.setValue("echo value");
+        var echoResponse = wsdlFirstServiceClient.echo(echo);
 
-        EchoResponse er = wsdlFirstServiceClient.echo(e);
-
-        return "Echo response: " + er.getValue() + " at " + LocalDateTime.now();
+        return "Echo response: " + echoResponse.getValue() + " at " + LocalDateTime.now();
     }
 }

--- a/dropwizard-jakarta-xml-ws-example/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/example/ws/HibernateExampleService.java
+++ b/dropwizard-jakarta-xml-ws-example/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/example/ws/HibernateExampleService.java
@@ -8,7 +8,6 @@ import org.kiwiproject.dropwizard.jakarta.xml.ws.example.core.Person;
 import org.kiwiproject.dropwizard.jakarta.xml.ws.example.db.PersonDAO;
 
 import java.util.List;
-import java.util.Optional;
 
 @WebService
 public class HibernateExampleService {
@@ -31,9 +30,9 @@ public class HibernateExampleService {
     @WebMethod
     @UnitOfWork
     public Person getPerson(long id) throws Exception {
-        Optional<Person> result = this.personDAO.findById(id);
-        if (result.isPresent()) {
-            return result.get();
+        var personOptional = this.personDAO.findById(id);
+        if (personOptional.isPresent()) {
+            return personOptional.get();
         }
 
         throw new Exception("Person with id " + id + " not found");

--- a/dropwizard-jakarta-xml-ws-example/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/example/ws/JavaFirstServiceImpl.java
+++ b/dropwizard-jakarta-xml-ws-example/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/example/ws/JavaFirstServiceImpl.java
@@ -27,7 +27,7 @@ public class JavaFirstServiceImpl implements JavaFirstService {
             throw new JavaFirstServiceException("Invalid parameter");
         }
 
-        Principal user = (Principal) wsContext.getMessageContext().get("dropwizard.jakarta.xml.ws.principal");
-        return in + "; principal: " + user.getName() + " at " + LocalDateTime.now();
+        var userPrincipal = (Principal) wsContext.getMessageContext().get("dropwizard.jakarta.xml.ws.principal");
+        return in + "; principal: " + userPrincipal.getName() + " at " + LocalDateTime.now();
     }
 }

--- a/dropwizard-jakarta-xml-ws-example/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/example/ws/MtomServiceImpl.java
+++ b/dropwizard-jakarta-xml-ws-example/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/example/ws/MtomServiceImpl.java
@@ -23,10 +23,10 @@ public class MtomServiceImpl implements MtomService {
     @Override
     public HelloResponse hello(Hello parameters) {
         try {
-            byte[] bin = IOUtils.readBytesFromStream(parameters.getBinary().getInputStream());
-            HelloResponse response = new HelloResponse();
+            var bytes = IOUtils.readBytesFromStream(parameters.getBinary().getInputStream());
+            var response = new HelloResponse();
             response.setTitle(parameters.getTitle());
-            response.setBinary(new DataHandler(new ByteArrayDataSource(bin,
+            response.setBinary(new DataHandler(new ByteArrayDataSource(bytes,
                     parameters.getBinary().getContentType())));
             return response;
         } catch (IOException e) {

--- a/dropwizard-jakarta-xml-ws-example/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/example/ws/WsdlFirstServiceImpl.java
+++ b/dropwizard-jakarta-xml-ws-example/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/example/ws/WsdlFirstServiceImpl.java
@@ -22,7 +22,7 @@ public class WsdlFirstServiceImpl implements WsdlFirstService {
     @Override
     @Metered
     public EchoResponse echo(Echo parameters) {
-        EchoResponse response = new EchoResponse();
+        var response = new EchoResponse();
         response.setValue(parameters.getValue());
         return response;
     }
@@ -31,7 +31,7 @@ public class WsdlFirstServiceImpl implements WsdlFirstService {
     @UseAsyncMethod
     @Metered
     public EchoResponse nonBlockingEcho(NonBlockingEcho parameters) {
-        EchoResponse response = new EchoResponse();
+        var response = new EchoResponse();
         response.setValue("Blocking: " + parameters.getValue());
         return response;
     }
@@ -40,21 +40,21 @@ public class WsdlFirstServiceImpl implements WsdlFirstService {
             final NonBlockingEcho parameters,
             final AsyncHandler<EchoResponse> asyncHandler) {
 
-        final ServerAsyncResponse<EchoResponse> sar = new ServerAsyncResponse<>();
+        final var asyncResponse = new ServerAsyncResponse<EchoResponse>();
 
         new Thread(() -> {
             try {
                 Thread.sleep(1000);
-                EchoResponse response = new EchoResponse();
+                var response = new EchoResponse();
                 response.setValue("Non-blocking: " + parameters.getValue());
-                sar.set(response);
+                asyncResponse.set(response);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                sar.exception(e);
+                asyncResponse.exception(e);
             }
-            asyncHandler.handleResponse(sar);
+            asyncHandler.handleResponse(asyncResponse);
         }).start();
 
-        return sar;
+        return asyncResponse;
     }
 }

--- a/dropwizard-jakarta-xml-ws/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/AbstractInvoker.java
+++ b/dropwizard-jakarta-xml-ws/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/AbstractInvoker.java
@@ -21,9 +21,9 @@ public abstract class AbstractInvoker implements Invoker {
      */
     public Method getTargetMethod(Exchange exchange) {
 
-        Object o = exchange.getBindingOperationInfo().getOperationInfo().getProperty(Method.class.getName());
+        var object = exchange.getBindingOperationInfo().getOperationInfo().getProperty(Method.class.getName());
 
-        if (o instanceof Method method) {
+        if (object instanceof Method method) {
             return method;
         } else {
             throw new IllegalStateException("Target method not found on OperationInfo");

--- a/dropwizard-jakarta-xml-ws/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/BasicAuthenticationInterceptor.java
+++ b/dropwizard-jakarta-xml-ws/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/BasicAuthenticationInterceptor.java
@@ -8,7 +8,6 @@ import org.apache.cxf.common.security.UsernameToken;
 import org.apache.cxf.configuration.security.AuthorizationPolicy;
 import org.apache.cxf.endpoint.Endpoint;
 import org.apache.cxf.interceptor.Fault;
-import org.apache.cxf.message.Exchange;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.phase.AbstractPhaseInterceptor;
 import org.apache.cxf.phase.Phase;
@@ -52,20 +51,20 @@ public class BasicAuthenticationInterceptor extends AbstractPhaseInterceptor<Mes
     @Override
     public void handleMessage(final Message message) throws Fault {
 
-        final Exchange exchange = message.getExchange();
+        final var exchange = message.getExchange();
 
         BasicCredentials credentials = null;
 
         try {
-            AuthorizationPolicy policy = message.get(AuthorizationPolicy.class);
+            var policy = message.get(AuthorizationPolicy.class);
             if (policy != null && policy.getUserName() != null && policy.getPassword() != null) {
                 credentials = new BasicCredentials(policy.getUserName(), policy.getPassword());
             } else {
                 // try the WS-Security UsernameToken
-                SecurityToken token = message.get(SecurityToken.class);
+                var token = message.get(SecurityToken.class);
                 if (token != null && token.getTokenType() == TokenType.UsernameToken) {
-                    UsernameToken ut = (UsernameToken) token;
-                    credentials = new BasicCredentials(ut.getName(), ut.getPassword());
+                    var usernameToken = (UsernameToken) token;
+                    credentials = new BasicCredentials(usernameToken.getName(), usernameToken.getPassword());
                 }
             }
 
@@ -90,7 +89,7 @@ public class BasicAuthenticationInterceptor extends AbstractPhaseInterceptor<Mes
     }
 
     private void sendErrorResponse(Message message, int responseCode) {
-        Message outMessage = getOutMessage(message);
+        var outMessage = getOutMessage(message);
         outMessage.put(Message.RESPONSE_CODE, responseCode);
         // Set the response headers
         @SuppressWarnings("unchecked")
@@ -109,10 +108,10 @@ public class BasicAuthenticationInterceptor extends AbstractPhaseInterceptor<Mes
     }
 
     private Message getOutMessage(Message inMessage) {
-        Exchange exchange = inMessage.getExchange();
-        Message outMessage = exchange.getOutMessage();
+        var exchange = inMessage.getExchange();
+        var outMessage = exchange.getOutMessage();
         if (outMessage == null) {
-            Endpoint endpoint = exchange.get(Endpoint.class);
+            var endpoint = exchange.get(Endpoint.class);
             outMessage = endpoint.getBinding().createMessage();
             exchange.setOutMessage(outMessage);
         }
@@ -121,15 +120,15 @@ public class BasicAuthenticationInterceptor extends AbstractPhaseInterceptor<Mes
     }
 
     private Conduit getConduit(Message inMessage) throws IOException {
-        Exchange exchange = inMessage.getExchange();
-        Conduit conduit = exchange.getDestination().getBackChannel(inMessage);
+        var exchange = inMessage.getExchange();
+        var conduit = exchange.getDestination().getBackChannel(inMessage);
         exchange.setConduit(conduit);
         return conduit;
     }
 
     private void close(Message outMessage) throws IOException {
-        OutputStream os = outMessage.getContent(OutputStream.class);
-        os.flush();
-        os.close();
+        var outputStream = outMessage.getContent(OutputStream.class);
+        outputStream.flush();
+        outputStream.close();
     }
 }

--- a/dropwizard-jakarta-xml-ws/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/InstrumentedInvokerFactory.java
+++ b/dropwizard-jakarta-xml-ws/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/InstrumentedInvokerFactory.java
@@ -28,13 +28,13 @@ public class InstrumentedInvokerFactory {
      */
     private Invoker timed(Invoker invoker, List<Method> timedMethods) {
 
-        ImmutableMap.Builder<String, Timer> timers = new ImmutableMap.Builder<>();
+        var timers = new ImmutableMap.Builder<String, Timer>();
 
-        for (Method m : timedMethods) {
-            Timed annotation = m.getAnnotation(Timed.class);
-            final String name = chooseName(annotation.name(), annotation.absolute(), m);
-            Timer timer = metricRegistry.timer(name);
-            timers.put(m.getName(), timer);
+        for (var method : timedMethods) {
+            var timed = method.getAnnotation(Timed.class);
+            var name = chooseName(timed.name(), timed.absolute(), method);
+            var timer = metricRegistry.timer(name);
+            timers.put(method.getName(), timer);
         }
 
         return new InstrumentedInvokers.TimedInvoker(invoker, timers.build());
@@ -45,13 +45,13 @@ public class InstrumentedInvokerFactory {
      */
     private Invoker metered(Invoker invoker, List<Method> meteredMethods) {
 
-        ImmutableMap.Builder<String, Meter> meters = new ImmutableMap.Builder<>();
+        var meters = new ImmutableMap.Builder<String, Meter>();
 
-        for (Method m : meteredMethods) {
-            Metered annotation = m.getAnnotation(Metered.class);
-            final String name = chooseName(annotation.name(), annotation.absolute(), m);
-            Meter meter = metricRegistry.meter(name);
-            meters.put(m.getName(), meter);
+        for (var method : meteredMethods) {
+            var metered = method.getAnnotation(Metered.class);
+            var name = chooseName(metered.name(), metered.absolute(), method);
+            var meter = metricRegistry.meter(name);
+            meters.put(method.getName(), meter);
         }
 
         return new InstrumentedInvokers.MeteredInvoker(invoker, meters.build());
@@ -62,19 +62,18 @@ public class InstrumentedInvokerFactory {
      */
     private Invoker exceptionMetered(Invoker invoker, List<Method> meteredMethods) {
 
-        ImmutableMap.Builder<String, InstrumentedInvokers.ExceptionMeter> meters =
-                new ImmutableMap.Builder<>();
+        var meters = new ImmutableMap.Builder<String, InstrumentedInvokers.ExceptionMeter>();
 
-        for (Method m : meteredMethods) {
+        for (var method : meteredMethods) {
 
-            ExceptionMetered annotation = m.getAnnotation(ExceptionMetered.class);
-            final String name = chooseName(
-                    annotation.name(),
-                    annotation.absolute(),
-                    m,
+            var exceptionMetered = method.getAnnotation(ExceptionMetered.class);
+            var name = chooseName(
+                    exceptionMetered.name(),
+                    exceptionMetered.absolute(),
+                    method,
                     ExceptionMetered.DEFAULT_NAME_SUFFIX);
-            Meter meter = metricRegistry.meter(name);
-            meters.put(m.getName(), new InstrumentedInvokers.ExceptionMeter(meter, annotation.cause()));
+            var meter = metricRegistry.meter(name);
+            meters.put(method.getName(), new InstrumentedInvokers.ExceptionMeter(meter, exceptionMetered.cause()));
         }
 
         return new InstrumentedInvokers.ExceptionMeteredInvoker(invoker, meters.build());
@@ -118,22 +117,22 @@ public class InstrumentedInvokerFactory {
         List<Method> meteredmethods = new ArrayList<>();
         List<Method> exceptionmeteredmethods = new ArrayList<>();
 
-        for (Method m : service.getClass().getMethods()) {
+        for (var method : service.getClass().getMethods()) {
 
-            if (m.isAnnotationPresent(Timed.class)) {
-                timedmethods.add(m);
+            if (method.isAnnotationPresent(Timed.class)) {
+                timedmethods.add(method);
             }
 
-            if (m.isAnnotationPresent(Metered.class)) {
-                meteredmethods.add(m);
+            if (method.isAnnotationPresent(Metered.class)) {
+                meteredmethods.add(method);
             }
 
-            if (m.isAnnotationPresent(ExceptionMetered.class)) {
-                exceptionmeteredmethods.add(m);
+            if (method.isAnnotationPresent(ExceptionMetered.class)) {
+                exceptionmeteredmethods.add(method);
             }
         }
 
-        Invoker invoker = rootInvoker;
+        var invoker = rootInvoker;
 
         if (!timedmethods.isEmpty()) {
             invoker = this.timed(invoker, timedmethods);

--- a/dropwizard-jakarta-xml-ws/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/InstrumentedInvokers.java
+++ b/dropwizard-jakarta-xml-ws/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/InstrumentedInvokers.java
@@ -35,13 +35,13 @@ public class InstrumentedInvokers {
         public Object invoke(Exchange exchange, Object o) {
 
             Object result;
-            String methodName = this.getTargetMethod(exchange).getName();
+            var methodName = this.getTargetMethod(exchange).getName();
 
             if (timers.containsKey(methodName)) {
                 var timer = requireNonNull(timers.get(methodName));
 
                 // Timer.Context is AutoCloseable, so this starts and closes (stops) the Timer.Context
-                try (Timer.Context ignored = timer.time()) {
+                try (var ignored = timer.time()) {
                     result = this.underlying.invoke(exchange, o);
                 }
             } else {
@@ -67,7 +67,7 @@ public class InstrumentedInvokers {
         public Object invoke(Exchange exchange, Object o) {
 
             Object result;
-            String methodName = this.getTargetMethod(exchange).getName();
+            var methodName = this.getTargetMethod(exchange).getName();
 
             if (meters.containsKey(methodName)) {
                 var meter = requireNonNull(meters.get(methodName));
@@ -112,7 +112,7 @@ public class InstrumentedInvokers {
         public Object invoke(Exchange exchange, Object o) {
 
             Object result;
-            String methodName = this.getTargetMethod(exchange).getName();
+            var methodName = this.getTargetMethod(exchange).getName();
 
             try {
                 result = this.underlying.invoke(exchange, o);

--- a/dropwizard-jakarta-xml-ws/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/JakartaXmlWsBundle.java
+++ b/dropwizard-jakarta-xml-ws/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/JakartaXmlWsBundle.java
@@ -64,7 +64,7 @@ public class JakartaXmlWsBundle<C> implements ConfiguredBundle<C> {
         environment.lifecycle().addServerLifecycleListener(
                 server -> jwsEnvironment.logEndpoints());
 
-        String publishedEndpointUrlPrefix = getPublishedEndpointUrlPrefix(configuration);
+        var publishedEndpointUrlPrefix = getPublishedEndpointUrlPrefix(configuration);
         if (publishedEndpointUrlPrefix != null) {
             jwsEnvironment.setPublishedEndpointUrlPrefix(publishedEndpointUrlPrefix);
         }

--- a/dropwizard-jakarta-xml-ws/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/UnitOfWorkInvoker.java
+++ b/dropwizard-jakarta-xml-ws/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/UnitOfWorkInvoker.java
@@ -8,7 +8,6 @@ import org.apache.cxf.message.Exchange;
 import org.apache.cxf.service.invoker.Invoker;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
-import org.hibernate.Transaction;
 import org.hibernate.context.internal.ManagedSessionContext;
 import org.hibernate.resource.transaction.spi.TransactionStatus;
 
@@ -44,12 +43,12 @@ public class UnitOfWorkInvoker extends AbstractInvoker {
     public Object invoke(Exchange exchange, Object o) {
 
         Object result;
-        String methodName = this.getTargetMethod(exchange).getName();
+        var methodName = this.getTargetMethod(exchange).getName();
 
         if (unitOfWorkMethods.containsKey(methodName)) {
 
             try (var session = sessionFactory.openSession()) {
-                UnitOfWork unitOfWork = requireNonNull(unitOfWorkMethods.get(methodName));
+                var unitOfWork = requireNonNull(unitOfWorkMethods.get(methodName));
                 configureSession(session, unitOfWork);
                 ManagedSessionContext.bind(session);
                 beginTransaction(session, unitOfWork);
@@ -96,7 +95,7 @@ public class UnitOfWorkInvoker extends AbstractInvoker {
     @SuppressWarnings("JavadocReference")
     private void rollbackTransaction(Session session, UnitOfWork unitOfWork) {
         if (unitOfWork.transactional()) {
-            final Transaction txn = session.getTransaction();
+            var txn = session.getTransaction();
             if (txn != null && txn.getStatus().equals(TransactionStatus.ACTIVE)) {
                 txn.rollback();
             }
@@ -109,7 +108,7 @@ public class UnitOfWorkInvoker extends AbstractInvoker {
     @SuppressWarnings("JavadocReference")
     private void commitTransaction(Session session, UnitOfWork unitOfWork) {
         if (unitOfWork.transactional()) {
-            final Transaction txn = session.getTransaction();
+            var txn = session.getTransaction();
             if (txn != null && txn.getStatus().equals(TransactionStatus.ACTIVE)) {
                 txn.commit();
             }

--- a/dropwizard-jakarta-xml-ws/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/UnitOfWorkInvokerFactory.java
+++ b/dropwizard-jakarta-xml-ws/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/UnitOfWorkInvokerFactory.java
@@ -5,8 +5,6 @@ import io.dropwizard.hibernate.UnitOfWork;
 import org.apache.cxf.service.invoker.Invoker;
 import org.hibernate.SessionFactory;
 
-import java.lang.reflect.Method;
-
 public class UnitOfWorkInvokerFactory {
 
     /**
@@ -14,20 +12,20 @@ public class UnitOfWorkInvokerFactory {
      */
     public Invoker create(Object service, Invoker rootInvoker, SessionFactory sessionFactory) {
 
-        var unitOfWorkMethodsBuilder = new ImmutableMap.Builder<String, UnitOfWork>();
+        var unitOfWorkMethodsMapBuilder = new ImmutableMap.Builder<String, UnitOfWork>();
 
-        for (Method m : service.getClass().getMethods()) {
-            if (m.isAnnotationPresent(UnitOfWork.class)) {
-                unitOfWorkMethodsBuilder.put(m.getName(), m.getAnnotation(UnitOfWork.class));
+        for (var method : service.getClass().getMethods()) {
+            if (method.isAnnotationPresent(UnitOfWork.class)) {
+                unitOfWorkMethodsMapBuilder.put(method.getName(), method.getAnnotation(UnitOfWork.class));
             }
         }
-        ImmutableMap<String, UnitOfWork> unitOfWorkMethods = unitOfWorkMethodsBuilder.build();
+        var unitOfWorkMethodsMap = unitOfWorkMethodsMapBuilder.build();
 
-        if (unitOfWorkMethods.isEmpty()) {
+        if (unitOfWorkMethodsMap.isEmpty()) {
             return rootInvoker;
         }
 
-        return new UnitOfWorkInvoker(rootInvoker, unitOfWorkMethods, sessionFactory);
+        return new UnitOfWorkInvoker(rootInvoker, unitOfWorkMethodsMap, sessionFactory);
     }
 
 }

--- a/dropwizard-jakarta-xml-ws/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/ValidatingInvoker.java
+++ b/dropwizard-jakarta-xml-ws/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/ValidatingInvoker.java
@@ -14,7 +14,6 @@ import org.apache.cxf.message.MessageContentsList;
 import org.apache.cxf.service.invoker.Invoker;
 
 import java.lang.annotation.Annotation;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -51,9 +50,9 @@ public class ValidatingInvoker extends AbstractInvoker {
 
         // validate each parameter in the list
         if (params != null) {
-            int i = 0;
+            var i = 0;
             try {
-                for (Object parameter : params) {
+                for (var parameter : params) {
                     if (parameter == null || !AsyncHandler.class.isAssignableFrom(parameter.getClass())) {
                         validate(parameterAnnotations[i++], parameter);
                     }
@@ -78,19 +77,19 @@ public class ValidatingInvoker extends AbstractInvoker {
      * java.lang.IllegalArgumentException: HV000116: The object to be validated must not be null.
      */
     private Object validate(Annotation[] annotations, Object value) {
-        final Class<?>[] classes = findValidationGroups(annotations);
+        var classes = findValidationGroups(annotations);
 
         if (classes != null && classes.length > 0) {
-            final Collection<String> errors = ConstraintViolations.format(
-                    validator.validate(value, classes));
-
-            if (!errors.isEmpty()) {
-                var message = new StringBuilder("\n");
-                for (String error : errors) {
-                    message.append("    ").append(error).append("\n");
-                }
-                throw new ValidationException(message.toString());
+            var errors = ConstraintViolations.format(validator.validate(value, classes));
+            if (errors.isEmpty()) {
+                return value;
             }
+
+            var message = new StringBuilder("\n");
+            for (var error : errors) {
+                message.append("    ").append(error).append("\n");
+            }
+            throw new ValidationException(message.toString());
         }
 
         return value;
@@ -100,7 +99,7 @@ public class ValidatingInvoker extends AbstractInvoker {
      * Copied from com.yammer.dropwizard.jersey.jackson.JacksonMessageBodyProvider#findValidationGroups()
      */
     private Class<?>[] findValidationGroups(Annotation[] annotations) {
-        for (Annotation annotation : annotations) {
+        for (var annotation : annotations) {
             if (annotation.annotationType() == Valid.class) {
                 return DEFAULT_GROUP_ARRAY;
             } else if (annotation.annotationType() == Validated.class) {

--- a/dropwizard-jakarta-xml-ws/src/test/java/org/kiwiproject/dropwizard/jakarta/xml/ws/BasicAuthenticationInterceptorTest.java
+++ b/dropwizard-jakarta-xml-ws/src/test/java/org/kiwiproject/dropwizard/jakarta/xml/ws/BasicAuthenticationInterceptorTest.java
@@ -58,52 +58,52 @@ class BasicAuthenticationInterceptorTest {
 
     @Test
     void shouldAuthenticateValidUser() {
-        BasicAuthenticationInterceptor target = new BasicAuthenticationInterceptor();
-        target.setAuthenticator(basicAuthentication);
-        Message message = createMessageWithUsernameAndPassword(USERNAME, CORRECT_PASSWORD);
+        var interceptor = new BasicAuthenticationInterceptor();
+        interceptor.setAuthenticator(basicAuthentication);
+        var message = createMessageWithUsernameAndPassword(USERNAME, CORRECT_PASSWORD);
 
-        target.handleMessage(message);
+        interceptor.handleMessage(message);
 
         verify(inMessageMock).put(eq(PRINCIPAL_KEY), any(Principal.class));
     }
 
     @Test
     void shouldReturnUnauthorizedCodeForInvalidCredentials() {
-        BasicAuthenticationInterceptor target = new BasicAuthenticationInterceptor();
-        target.setAuthenticator(basicAuthentication);
-        Message message = createMessageWithUsernameAndPassword(USERNAME, "foo");
+        var interceptor = new BasicAuthenticationInterceptor();
+        interceptor.setAuthenticator(basicAuthentication);
+        var message = createMessageWithUsernameAndPassword(USERNAME, "foo");
 
-        target.handleMessage(message);
+        interceptor.handleMessage(message);
 
         verify(outMessageMock).put(Message.RESPONSE_CODE, HttpURLConnection.HTTP_UNAUTHORIZED);
     }
 
     @Test
     void shouldNotCrashOnNullPassword() {
-        BasicAuthenticationInterceptor target = new BasicAuthenticationInterceptor();
-        target.setAuthenticator(basicAuthentication);
-        Message message = createMessageWithUsernameAndPassword(USERNAME, null);
+        var interceptor = new BasicAuthenticationInterceptor();
+        interceptor.setAuthenticator(basicAuthentication);
+        var message = createMessageWithUsernameAndPassword(USERNAME, null);
 
-        target.handleMessage(message);
+        interceptor.handleMessage(message);
 
         verify(outMessageMock).put(Message.RESPONSE_CODE, HttpURLConnection.HTTP_UNAUTHORIZED);
     }
 
     @Test
     void shouldNotCrashOnNullUser() {
-        BasicAuthenticationInterceptor target = new BasicAuthenticationInterceptor();
-        target.setAuthenticator(basicAuthentication);
-        Message message = createMessageWithUsernameAndPassword(null, CORRECT_PASSWORD);
+        var interceptor = new BasicAuthenticationInterceptor();
+        interceptor.setAuthenticator(basicAuthentication);
+        var message = createMessageWithUsernameAndPassword(null, CORRECT_PASSWORD);
 
-        target.handleMessage(message);
+        interceptor.handleMessage(message);
 
         verify(outMessageMock).put(Message.RESPONSE_CODE, HttpURLConnection.HTTP_UNAUTHORIZED);
     }
 
     private Message createMessageWithUsernameAndPassword(String username, String password) {
-        Message message = createEmptyMessage();
+        var message = createEmptyMessage();
 
-        AuthorizationPolicy policy = new AuthorizationPolicy();
+        var policy = new AuthorizationPolicy();
         policy.setUserName(username);
         policy.setPassword(password);
         message.put(AuthorizationPolicy.class, policy);

--- a/dropwizard-jakarta-xml-ws/src/test/java/org/kiwiproject/dropwizard/jakarta/xml/ws/ClientBuilderTest.java
+++ b/dropwizard-jakarta-xml-ws/src/test/java/org/kiwiproject/dropwizard/jakarta/xml/ws/ClientBuilderTest.java
@@ -19,7 +19,7 @@ class ClientBuilderTest {
         Interceptor<?> outInterceptor = mock(Interceptor.class);
         Interceptor<?> outFaultInterceptor = mock(Interceptor.class);
 
-        ClientBuilder<Object> builder = new ClientBuilder<>(Object.class, "address")
+        var builder = new ClientBuilder<>(Object.class, "address")
                 .connectTimeout(1234)
                 .receiveTimeout(5678)
                 .handlers(handler, handler)

--- a/dropwizard-jakarta-xml-ws/src/test/java/org/kiwiproject/dropwizard/jakarta/xml/ws/EndpointBuilderTest.java
+++ b/dropwizard-jakarta-xml-ws/src/test/java/org/kiwiproject/dropwizard/jakarta/xml/ws/EndpointBuilderTest.java
@@ -14,11 +14,11 @@ class EndpointBuilderTest {
 
     @Test
     void buildEndpoint() {
-        Object service = new Object();
-        String path = "/foo";
-        String publishedUrl = "http://external/url";
-        BasicAuthentication basicAuth = mock(BasicAuthentication.class);
-        SessionFactory sessionFactory = mock(SessionFactory.class);
+        var service = new Object();
+        var path = "/foo";
+        var publishedUrl = "http://external/url";
+        var basicAuth = mock(BasicAuthentication.class);
+        var sessionFactory = mock(SessionFactory.class);
         Interceptor<?> inInterceptor = mock(Interceptor.class);
         Interceptor<?> inFaultInterceptor = mock(Interceptor.class);
         Interceptor<?> outInterceptor = mock(Interceptor.class);
@@ -26,7 +26,7 @@ class EndpointBuilderTest {
         Map<String, Object> props = new HashMap<>();
         props.put("key", "value");
 
-        EndpointBuilder builder = new EndpointBuilder(path, service)
+        var builder = new EndpointBuilder(path, service)
                 .publishedEndpointUrl(publishedUrl)
                 .authentication(basicAuth)
                 .sessionFactory(sessionFactory)

--- a/dropwizard-jakarta-xml-ws/src/test/java/org/kiwiproject/dropwizard/jakarta/xml/ws/JakartaXmlWsBundleTest.java
+++ b/dropwizard-jakarta-xml-ws/src/test/java/org/kiwiproject/dropwizard/jakarta/xml/ws/JakartaXmlWsBundleTest.java
@@ -113,9 +113,8 @@ class JakartaXmlWsBundleTest {
     @SuppressWarnings("resource")
     @Test
     void publishEndpoint() {
-
-        JakartaXmlWsBundle<?> jwsBundle = new JakartaXmlWsBundle<>("/soap", jwsEnvironment);
-        Object service = new Object();
+        var jwsBundle = new JakartaXmlWsBundle<>("/soap", jwsEnvironment);
+        var service = new Object();
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> jwsBundle.publishEndpoint(new EndpointBuilder("foo", null)))
                 .withMessage("Service is null");
@@ -129,18 +128,17 @@ class JakartaXmlWsBundleTest {
                 .isThrownBy(() -> jwsBundle.publishEndpoint(new EndpointBuilder("   ", service)))
                 .withMessage("Path is empty");
 
-        EndpointBuilder builder = mock(EndpointBuilder.class);
+        var builder = mock(EndpointBuilder.class);
         jwsBundle.publishEndpoint(builder);
         verify(jwsEnvironment).publishEndpoint(builder);
     }
 
     @Test
     void getClient() {
-
         JakartaXmlWsBundle<?> jwsBundle = new JakartaXmlWsBundle<>("/soap", jwsEnvironment);
 
         Class<?> cls = Object.class;
-        String url = "http://foo";
+        var url = "http://foo";
 
         //noinspection DataFlowIssue
         assertThatIllegalArgumentException()
@@ -160,7 +158,7 @@ class JakartaXmlWsBundleTest {
                 .isThrownBy(() -> jwsBundle.getClient(new ClientBuilder<>(cls, " ")))
                 .withMessage("Address is empty");
 
-        ClientBuilder<?> builder = new ClientBuilder<>(cls, url);
+        var builder = new ClientBuilder<>(cls, url);
         jwsBundle.getClient(builder);
         verify(jwsEnvironment).getClient(builder);
     }

--- a/dropwizard-jakarta-xml-ws/src/test/java/org/kiwiproject/dropwizard/jakarta/xml/ws/JakartaXmlWsEnvironmentTest.java
+++ b/dropwizard-jakarta-xml-ws/src/test/java/org/kiwiproject/dropwizard/jakarta/xml/ws/JakartaXmlWsEnvironmentTest.java
@@ -15,13 +15,10 @@ import jakarta.jws.WebService;
 import jakarta.mail.internet.MimeMultipart;
 import jakarta.mail.util.ByteArrayDataSource;
 import jakarta.xml.ws.BindingProvider;
-import jakarta.xml.ws.Endpoint;
 import jakarta.xml.ws.handler.Handler;
 import jakarta.xml.ws.soap.SOAPBinding;
 import org.apache.cxf.Bus;
 import org.apache.cxf.binding.soap.SoapBindingFactory;
-import org.apache.cxf.endpoint.Client;
-import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.frontend.ClientProxy;
 import org.apache.cxf.frontend.WSDLGetUtils;
 import org.apache.cxf.interceptor.Fault;
@@ -36,17 +33,16 @@ import org.apache.cxf.transport.AbstractDestination;
 import org.apache.cxf.transport.http.HTTPConduit;
 import org.apache.cxf.transport.local.LocalTransportFactory;
 import org.apache.cxf.transport.servlet.CXFNonSpringServlet;
-import org.apache.cxf.transports.http.configuration.HTTPClientPolicy;
 import org.hibernate.SessionFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
-import org.w3c.dom.Node;
 
-import javax.wsdl.WSDLException;
 import java.lang.reflect.Proxy;
 import java.util.HashMap;
+
+import javax.wsdl.WSDLException;
 
 class JakartaXmlWsEnvironmentTest {
 
@@ -143,19 +139,18 @@ class JakartaXmlWsEnvironmentTest {
 
     @Test
     void publishEndpoint() throws Exception {
-
-        Endpoint e = jwsEnvironment.publishEndpoint(new EndpointBuilder("local://path", service));
-        assertThat(e).isNotNull();
+        var endpoint = jwsEnvironment.publishEndpoint(new EndpointBuilder("local://path", service));
+        assertThat(endpoint).isNotNull();
 
         verify(mockInvokerBuilder).create(any(), any(Invoker.class));
         verifyNoInteractions(mockUnitOfWorkInvokerBuilder);
 
-        Node soapResponse = testutils.invoke("local://path",
+        var soapResponseNode = testutils.invoke("local://path",
                 LocalTransportFactory.TRANSPORT_ID, SOAP_REQUEST_FILE_NAME);
 
         verify(mockInvoker).invoke(any(Exchange.class), any());
 
-        testutils.assertValid("/soap:Envelope/soap:Body/a:fooResponse", soapResponse);
+        testutils.assertValid("/soap:Envelope/soap:Body/a:fooResponse", soapResponseNode);
     }
 
     @Test
@@ -173,17 +168,16 @@ class JakartaXmlWsEnvironmentTest {
         verify(mockInvokerBuilder).create(any(), any(Invoker.class));
         verifyNoInteractions(mockUnitOfWorkInvokerBuilder);
 
-        Node soapResponse = testutils.invoke("local://path",
+        var soapResponseNode = testutils.invoke("local://path",
                 LocalTransportFactory.TRANSPORT_ID, SOAP_REQUEST_FILE_NAME);
 
         verify(mockInvoker).invoke(any(Exchange.class), any());
 
-        testutils.assertValid("/soap:Envelope/soap:Body/a:fooResponse", soapResponse);
+        testutils.assertValid("/soap:Envelope/soap:Body/a:fooResponse", soapResponseNode);
     }
 
     @Test
     void publishEndpointWithAuthentication() throws Exception {
-
         jwsEnvironment.publishEndpoint(
                 new EndpointBuilder("local://path", service)
                         .authentication(mock(BasicAuthentication.class)));
@@ -191,19 +185,18 @@ class JakartaXmlWsEnvironmentTest {
         verify(mockInvokerBuilder).create(any(), any(Invoker.class));
         verifyNoInteractions(mockUnitOfWorkInvokerBuilder);
 
-        Node soapResponse = testutils.invoke("local://path",
+        var soapResponseNode = testutils.invoke("local://path",
                 LocalTransportFactory.TRANSPORT_ID, SOAP_REQUEST_FILE_NAME);
 
         verify(mockInvoker).invoke(any(Exchange.class), any());
 
-        testutils.assertValid("/soap:Envelope/soap:Body/a:fooResponse", soapResponse);
+        testutils.assertValid("/soap:Envelope/soap:Body/a:fooResponse", soapResponseNode);
 
         assertThat(mockBasicAuthInterceptorInvoked).isEqualTo(1);
     }
 
     @Test
     void publishEndpointWithHibernateInvoker() throws Exception {
-
         jwsEnvironment.publishEndpoint(
                 new EndpointBuilder("local://path", service)
                         .sessionFactory(mock(SessionFactory.class)));
@@ -211,20 +204,19 @@ class JakartaXmlWsEnvironmentTest {
         verify(mockInvokerBuilder).create(any(), any(Invoker.class));
         verify(mockUnitOfWorkInvokerBuilder).create(any(), any(Invoker.class), any(SessionFactory.class));
 
-        Node soapResponse = testutils.invoke("local://path",
+        var soapResponseNode = testutils.invoke("local://path",
                 LocalTransportFactory.TRANSPORT_ID, SOAP_REQUEST_FILE_NAME);
 
         verify(mockInvoker).invoke(any(Exchange.class), any());
 
-        testutils.assertValid("/soap:Envelope/soap:Body/a:fooResponse", soapResponse);
+        testutils.assertValid("/soap:Envelope/soap:Body/a:fooResponse", soapResponseNode);
     }
 
     @Test
     void publishEndpointWithCxfInterceptors() throws Exception {
-
-        TestInterceptor inInterceptor = new TestInterceptor(Phase.UNMARSHAL);
-        TestInterceptor inInterceptor2 = new TestInterceptor(Phase.PRE_INVOKE);
-        TestInterceptor outInterceptor = new TestInterceptor(Phase.MARSHAL);
+        var inInterceptor = new TestInterceptor(Phase.UNMARSHAL);
+        var inInterceptor2 = new TestInterceptor(Phase.PRE_INVOKE);
+        var outInterceptor = new TestInterceptor(Phase.MARSHAL);
 
         jwsEnvironment.publishEndpoint(
                 new EndpointBuilder("local://path", service)
@@ -233,7 +225,7 @@ class JakartaXmlWsEnvironmentTest {
 
         verify(mockInvokerBuilder).create(any(), any(Invoker.class));
 
-        Node soapResponse = testutils.invoke("local://path",
+        var soapResponseNode = testutils.invoke("local://path",
                 LocalTransportFactory.TRANSPORT_ID, SOAP_REQUEST_FILE_NAME);
 
         verify(mockInvoker).invoke(any(Exchange.class), any());
@@ -241,9 +233,9 @@ class JakartaXmlWsEnvironmentTest {
         assertThat(inInterceptor2.getInvocationCount()).isEqualTo(1);
         assertThat(outInterceptor.getInvocationCount()).isEqualTo(1);
 
-        testutils.assertValid("/soap:Envelope/soap:Body/a:fooResponse", soapResponse);
+        testutils.assertValid("/soap:Envelope/soap:Body/a:fooResponse", soapResponseNode);
 
-        soapResponse = testutils.invoke("local://path",
+        soapResponseNode = testutils.invoke("local://path",
                 LocalTransportFactory.TRANSPORT_ID, SOAP_REQUEST_FILE_NAME);
 
         verify(mockInvoker, times(2)).invoke(any(Exchange.class), any());
@@ -251,24 +243,23 @@ class JakartaXmlWsEnvironmentTest {
         assertThat(inInterceptor2.getInvocationCount()).isEqualTo(2);
         assertThat(outInterceptor.getInvocationCount()).isEqualTo(2);
 
-        testutils.assertValid("/soap:Envelope/soap:Body/a:fooResponse", soapResponse);
+        testutils.assertValid("/soap:Envelope/soap:Body/a:fooResponse", soapResponseNode);
     }
 
 
     @Test
     void publishEndpointWithMtom() throws Exception {
-
         jwsEnvironment.publishEndpoint(
                 new EndpointBuilder("local://path", service)
                         .enableMtom());
 
         verify(mockInvokerBuilder).create(any(), any(Invoker.class));
 
-        byte[] response = testutils.invokeBytes("local://path", LocalTransportFactory.TRANSPORT_ID, SOAP_REQUEST_FILE_NAME);
+        var bytes = testutils.invokeBytes("local://path", LocalTransportFactory.TRANSPORT_ID, SOAP_REQUEST_FILE_NAME);
 
         verify(mockInvoker).invoke(any(Exchange.class), any());
 
-        MimeMultipart mimeMultipart = new MimeMultipart(new ByteArrayDataSource(response,
+        var mimeMultipart = new MimeMultipart(new ByteArrayDataSource(bytes,
                 "application/xop+xml; charset=UTF-8; type=\"text/xml\""));
         assertThat(mimeMultipart.getCount()).isEqualTo(1);
         testutils.assertValid("/soap:Envelope/soap:Body/a:fooResponse",
@@ -286,40 +277,39 @@ class JakartaXmlWsEnvironmentTest {
         verify(mockInvokerBuilder).create(any(), any(Invoker.class));
         verifyNoInteractions(mockUnitOfWorkInvokerBuilder);
 
-        Server server = testutils.getServerForAddress("local://path");
-        AbstractDestination destination = (AbstractDestination) server.getDestination();
-        String publishedEndpointUrl = destination.getEndpointInfo().getProperty(WSDLGetUtils.PUBLISHED_ENDPOINT_URL, String.class);
+        var server = testutils.getServerForAddress("local://path");
+        var destination = (AbstractDestination) server.getDestination();
+        var publishedEndpointUrl = destination.getEndpointInfo()
+                .getProperty(WSDLGetUtils.PUBLISHED_ENDPOINT_URL, String.class);
 
         assertThat(publishedEndpointUrl).isEqualTo("http://external.server/external/path");
     }
 
     @Test
     void publishEndpointWithProperties() throws Exception {
-
-        HashMap<String, Object> props = new HashMap<>();
+        var props = new HashMap<String, Object>();
         props.put("key", "value");
 
-        Endpoint e = jwsEnvironment.publishEndpoint(
+        var endpoint = jwsEnvironment.publishEndpoint(
                 new EndpointBuilder("local://path", service)
                         .properties(props));
 
-        assertThat(e).isNotNull();
-        assertThat(e.getProperties()).containsEntry("key", "value");
+        assertThat(endpoint).isNotNull();
+        assertThat(endpoint.getProperties()).containsEntry("key", "value");
 
         verify(mockInvokerBuilder).create(any(), any(Invoker.class));
         verifyNoInteractions(mockUnitOfWorkInvokerBuilder);
 
-        Node soapResponse = testutils.invoke("local://path",
+        var soapResponseNode = testutils.invoke("local://path",
                 LocalTransportFactory.TRANSPORT_ID, SOAP_REQUEST_FILE_NAME);
 
         verify(mockInvoker).invoke(any(Exchange.class), any());
 
-        testutils.assertValid("/soap:Envelope/soap:Body/a:fooResponse", soapResponse);
+        testutils.assertValid("/soap:Envelope/soap:Body/a:fooResponse", soapResponseNode);
     }
 
     @Test
     void publishEndpointWithPublishedUrlPrefix() throws WSDLException {
-
         jwsEnvironment.setPublishedEndpointUrlPrefix("http://external/prefix");
 
         jwsEnvironment.publishEndpoint(
@@ -329,16 +319,16 @@ class JakartaXmlWsEnvironmentTest {
         verify(mockInvokerBuilder).create(any(), any(Invoker.class));
         verifyNoInteractions(mockUnitOfWorkInvokerBuilder);
 
-        Server server = testutils.getServerForAddress("/path");
-        AbstractDestination destination = (AbstractDestination) server.getDestination();
-        String publishedEndpointUrl = destination.getEndpointInfo().getProperty(WSDLGetUtils.PUBLISHED_ENDPOINT_URL, String.class);
+        var server = testutils.getServerForAddress("/path");
+        var destination = (AbstractDestination) server.getDestination();
+        var publishedEndpointUrl = destination.getEndpointInfo()
+                .getProperty(WSDLGetUtils.PUBLISHED_ENDPOINT_URL, String.class);
 
         assertThat(publishedEndpointUrl).isEqualTo("http://external/prefix/path");
     }
 
     @Test
     void publishEndpointWithInvalidArguments() {
-
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> new EndpointBuilder("foo", null))
                 .withMessage("Service is null");
@@ -355,30 +345,29 @@ class JakartaXmlWsEnvironmentTest {
 
     @Test
     void getClient() {
-
         var address = "http://address";
         var handler = mock(Handler.class);
 
         // simple
-        DummyInterface clientProxy = jwsEnvironment.getClient(
+        var clientProxy = jwsEnvironment.getClient(
                 new ClientBuilder<>(DummyInterface.class, address)
         );
         assertThat(clientProxy).isInstanceOf(Proxy.class);
 
-        Client c = ClientProxy.getClient(clientProxy);
-        assertThat(c.getEndpoint().getEndpointInfo().getAddress()).isEqualTo(address);
-        assertThat(c.getEndpoint().getService()).containsEntry("endpoint.class", DummyInterface.class);
+        var client = ClientProxy.getClient(clientProxy);
+        assertThat(client.getEndpoint().getEndpointInfo().getAddress()).isEqualTo(address);
+        assertThat(client.getEndpoint().getService()).containsEntry("endpoint.class", DummyInterface.class);
         assertThat(((BindingProvider) clientProxy).getBinding().getHandlerChain()).isEmpty();
 
-        HTTPClientPolicy httpclient = ((HTTPConduit) c.getConduit()).getClient();
-        assertThat(httpclient.getConnectionTimeout()).isEqualTo(500L);
-        assertThat(httpclient.getReceiveTimeout()).isEqualTo(2000L);
+        var httpClientPolicy = ((HTTPConduit) client.getConduit()).getClient();
+        assertThat(httpClientPolicy.getConnectionTimeout()).isEqualTo(500L);
+        assertThat(httpClientPolicy.getReceiveTimeout()).isEqualTo(2000L);
 
         // with timeouts, handlers, interceptors, properties and MTOM
 
-        TestInterceptor inInterceptor = new TestInterceptor(Phase.UNMARSHAL);
-        TestInterceptor inInterceptor2 = new TestInterceptor(Phase.PRE_INVOKE);
-        TestInterceptor outInterceptor = new TestInterceptor(Phase.MARSHAL);
+        var inInterceptor = new TestInterceptor(Phase.UNMARSHAL);
+        var inInterceptor2 = new TestInterceptor(Phase.PRE_INVOKE);
+        var outInterceptor = new TestInterceptor(Phase.MARSHAL);
 
         clientProxy = jwsEnvironment.getClient(
                 new ClientBuilder<>(DummyInterface.class, address)
@@ -389,19 +378,19 @@ class JakartaXmlWsEnvironmentTest {
                         .cxfInInterceptors(inInterceptor, inInterceptor2)
                         .cxfOutInterceptors(outInterceptor)
                         .enableMtom());
-        c = ClientProxy.getClient(clientProxy);
+        client = ClientProxy.getClient(clientProxy);
         assertThat(((BindingProvider) clientProxy).getBinding().getBindingID()).isEqualTo("http://www.w3.org/2003/05/soap/bindings/HTTP/");
-        assertThat(c.getEndpoint().getEndpointInfo().getAddress()).isEqualTo(address);
-        assertThat(c.getEndpoint().getService()).containsEntry("endpoint.class", DummyInterface.class);
+        assertThat(client.getEndpoint().getEndpointInfo().getAddress()).isEqualTo(address);
+        assertThat(client.getEndpoint().getService()).containsEntry("endpoint.class", DummyInterface.class);
 
-        httpclient = ((HTTPConduit) c.getConduit()).getClient();
-        assertThat(httpclient.getConnectionTimeout()).isEqualTo(123L);
-        assertThat(httpclient.getReceiveTimeout()).isEqualTo(456L);
+        httpClientPolicy = ((HTTPConduit) client.getConduit()).getClient();
+        assertThat(httpClientPolicy.getConnectionTimeout()).isEqualTo(123L);
+        assertThat(httpClientPolicy.getReceiveTimeout()).isEqualTo(456L);
 
         assertThat(((BindingProvider) clientProxy).getBinding().getHandlerChain()).contains(handler);
 
-        BindingProvider bp = (BindingProvider) clientProxy;
-        SOAPBinding binding = (SOAPBinding) bp.getBinding();
-        assertThat(binding.isMTOMEnabled()).isTrue();
+        var bindingProvider = (BindingProvider) clientProxy;
+        var soapBinding = (SOAPBinding) bindingProvider.getBinding();
+        assertThat(soapBinding.isMTOMEnabled()).isTrue();
     }
 }

--- a/dropwizard-jakarta-xml-ws/src/test/java/org/kiwiproject/dropwizard/jakarta/xml/ws/UnitOfWorkInvokerFactoryTest.java
+++ b/dropwizard-jakarta-xml-ws/src/test/java/org/kiwiproject/dropwizard/jakarta/xml/ws/UnitOfWorkInvokerFactoryTest.java
@@ -86,10 +86,10 @@ class UnitOfWorkInvokerFactoryTest {
     @BeforeEach
     void setUp() {
         exchange = mock(Exchange.class);
-        BindingOperationInfo boi = mock(BindingOperationInfo.class);
-        when(exchange.getBindingOperationInfo()).thenReturn(boi);
-        OperationInfo oi = mock(OperationInfo.class);
-        when(boi.getOperationInfo()).thenReturn(oi);
+        var bindingOperationInfo = mock(BindingOperationInfo.class);
+        when(exchange.getBindingOperationInfo()).thenReturn(bindingOperationInfo);
+        var operationInfo = mock(OperationInfo.class);
+        when(bindingOperationInfo.getOperationInfo()).thenReturn(operationInfo);
         invokerBuilder = new UnitOfWorkInvokerFactory();
         fooService = new FooService();
         barService = new BarService();
@@ -108,8 +108,8 @@ class UnitOfWorkInvokerFactoryTest {
     private void setTargetMethod(Exchange exchange, Class<?> serviceClass, String methodName, Class<?>... parameterTypes) {
 
         try {
-            OperationInfo oi = exchange.getBindingOperationInfo().getOperationInfo();
-            when(oi.getProperty(Method.class.getName()))
+            var operationInfo = exchange.getBindingOperationInfo().getOperationInfo();
+            when(operationInfo.getProperty(Method.class.getName()))
                     .thenReturn(serviceClass.getMethod(methodName, parameterTypes));
         } catch (Exception e) {
             throw new RuntimeException("setTargetMethod failed", e);
@@ -118,10 +118,10 @@ class UnitOfWorkInvokerFactoryTest {
 
     @Test
     void noAnnotation() {
-        Invoker invoker = invokerBuilder.create(fooService, new FooInvoker(), sessionFactory);
+        var invoker = invokerBuilder.create(fooService, new FooInvoker(), sessionFactory);
         this.setTargetMethod(exchange, FooService.class, "foo"); // simulate CXF behavior
 
-        Object result = invoker.invoke(exchange, null);
+        var result = invoker.invoke(exchange, null);
         assertThat(result).isEqualTo("foo return");
 
         verifyNoInteractions(sessionFactory);
@@ -145,10 +145,10 @@ class UnitOfWorkInvokerFactoryTest {
     @Test
     void unitOfWorkAnnotation() {
         // use underlying invoker which invokes fooService.unitOfWork(false)
-        Invoker invoker = invokerBuilder.create(fooService, new UnitOfWorkInvoker(false), sessionFactory);
+        var invoker = invokerBuilder.create(fooService, new UnitOfWorkInvoker(false), sessionFactory);
         this.setTargetMethod(exchange, FooService.class, "unitOfWork", boolean.class); // simulate CXF behavior
 
-        Object result = invoker.invoke(exchange, null);
+        var result = invoker.invoke(exchange, null);
         assertThat(result).isEqualTo("unitOfWork return");
 
         verify(session, times(1)).beginTransaction();
@@ -160,7 +160,7 @@ class UnitOfWorkInvokerFactoryTest {
     @Test
     void unitOfWorkWithException() {
         // use underlying invoker which invokes fooService.unitOfWork(true) - exception is thrown
-        Invoker invoker = invokerBuilder.create(fooService, new UnitOfWorkInvoker(true), sessionFactory);
+        var invoker = invokerBuilder.create(fooService, new UnitOfWorkInvoker(true), sessionFactory);
         this.setTargetMethod(exchange, FooService.class, "unitOfWork", boolean.class);  // simulate CXF behavior
 
         assertThatRuntimeException()

--- a/dropwizard-jakarta-xml-ws/src/test/java/org/kiwiproject/dropwizard/jakarta/xml/ws/ValidatingInvokerTest.java
+++ b/dropwizard-jakarta-xml-ws/src/test/java/org/kiwiproject/dropwizard/jakarta/xml/ws/ValidatingInvokerTest.java
@@ -94,10 +94,10 @@ class ValidatingInvokerTest {
         invoker = new ValidatingInvoker(underlying, Validation.buildDefaultValidatorFactory().getValidator());
         exchange = mock(Exchange.class);
         when(exchange.getInMessage()).thenReturn(mock(Message.class));
-        BindingOperationInfo boi = mock(BindingOperationInfo.class);
-        when(exchange.getBindingOperationInfo()).thenReturn(boi);
-        OperationInfo oi = mock(OperationInfo.class);
-        when(boi.getOperationInfo()).thenReturn(oi);
+        var bindingOperationInfo = mock(BindingOperationInfo.class);
+        when(exchange.getBindingOperationInfo()).thenReturn(bindingOperationInfo);
+        var operationInfo = mock(OperationInfo.class);
+        when(bindingOperationInfo.getOperationInfo()).thenReturn(operationInfo);
     }
 
     /**
@@ -106,8 +106,8 @@ class ValidatingInvokerTest {
      */
     private void setTargetMethod(Exchange exchange, String methodName, Class<?>... parameterTypes) {
         try {
-            OperationInfo oi = exchange.getBindingOperationInfo().getOperationInfo();
-            when(oi.getProperty(Method.class.getName()))
+            var operationInfo = exchange.getBindingOperationInfo().getOperationInfo();
+            when(operationInfo.getProperty(Method.class.getName()))
                     .thenReturn(DummyService.class.getMethod(methodName, parameterTypes));
         } catch (Exception e) {
             throw new RuntimeException("setTargetMethod failed", e);
@@ -125,7 +125,7 @@ class ValidatingInvokerTest {
     void invokeWithoutValidation() {
         setTargetMethod(exchange, "noValidation", RootParam1.class, RootParam2.class);
 
-        List<Object> params = Arrays.asList(null, null);
+        var params = Arrays.asList(null, null);
         invoker.invoke(exchange, params);
         verify(underlying).invoke(exchange, params);
 


### PR DESCRIPTION
* Change explicit type declarations to use 'var'
* Rename local vars from short names like 'm' and 'sr' to more descriptive ones like 'method' and 'serverRegistry'

And no, I don't care if you ever read this and prefer code like Foo foo = new Foo()