### PR TITLE
Add required dependencies explicitly in the POM

### DIFF
--- a/dropwizard-jakarta-xml-ws/pom.xml
+++ b/dropwizard-jakarta-xml-ws/pom.xml
@@ -11,7 +11,13 @@
     <artifactId>dropwizard-jakarta-xml-ws</artifactId>
     <name>Dropwizard Jakarta XML Web Services Bundle</name>
 
+    <properties>
+        <jakarta.xml.ws-api.version>3.0.1</jakarta.xml.ws-api.version>
+    </properties>
+
     <dependencies>
+
+        <!-- Required dependencies -->
 
         <dependency>
             <groupId>org.checkerframework</groupId>
@@ -19,21 +25,13 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.dropwizard</groupId>
-            <artifactId>dropwizard-auth</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.dropwizard</groupId>
-            <artifactId>dropwizard-hibernate</artifactId>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -47,6 +45,48 @@
             <artifactId>cxf-rt-transports-http</artifactId>
             <version>${cxf.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
+            <version>${jakarta.xml.ws-api.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!-- Provided dependencies -->
+
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-auth</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-hibernate</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Test dependencies -->
 
         <dependency>
             <groupId>org.apache.cxf</groupId>

--- a/dropwizard-jakarta-xml-ws/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/ValidatingInvoker.java
+++ b/dropwizard-jakarta-xml-ws/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/ValidatingInvoker.java
@@ -3,6 +3,7 @@ package org.kiwiproject.dropwizard.jakarta.xml.ws;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.dropwizard.validation.ConstraintViolations;
 import io.dropwizard.validation.Validated;
 import jakarta.validation.Valid;
@@ -79,6 +80,7 @@ public class ValidatingInvoker extends AbstractInvoker {
      * for null parameter values:
      * java.lang.IllegalArgumentException: HV000116: The object to be validated must not be null.
      */
+    @CanIgnoreReturnValue
     private Object validate(Annotation[] annotations, Object value) {
         var classes = findValidationGroups(annotations);
 


### PR DESCRIPTION
* Add error_prone_annotations dependency and add CanIgnoreReturnValue to ValidatingInvoker#validate method.
* Add guava dependency
* Add jakarta.servlet-api dependency
* Add jakarta.validation-api dependency
* Add jakarta.xml.ws-api dependency
* Add slf4j-api dependency
* Move the two provided dependencies to a separate "Provided dependencies" section in the POM

Closes #118
Closes #119