### PR TITLE
Code cleanup: more LVTI, renaming methods, removing redundant warnings

### DIFF
--- a/dropwizard-jakarta-xml-ws/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/InstrumentedInvokerFactory.java
+++ b/dropwizard-jakarta-xml-ws/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/InstrumentedInvokerFactory.java
@@ -115,37 +115,37 @@ public class InstrumentedInvokerFactory {
      */
     public Invoker create(Object service, Invoker rootInvoker) {
 
-        List<Method> timedmethods = new ArrayList<>();
-        List<Method> meteredmethods = new ArrayList<>();
-        List<Method> exceptionmeteredmethods = new ArrayList<>();
+        List<Method> timedMethods = new ArrayList<>();
+        List<Method> meteredMethods = new ArrayList<>();
+        List<Method> exceptionMeteredMethods = new ArrayList<>();
 
         for (var method : service.getClass().getMethods()) {
 
             if (method.isAnnotationPresent(Timed.class)) {
-                timedmethods.add(method);
+                timedMethods.add(method);
             }
 
             if (method.isAnnotationPresent(Metered.class)) {
-                meteredmethods.add(method);
+                meteredMethods.add(method);
             }
 
             if (method.isAnnotationPresent(ExceptionMetered.class)) {
-                exceptionmeteredmethods.add(method);
+                exceptionMeteredMethods.add(method);
             }
         }
 
         var invoker = rootInvoker;
 
-        if (!timedmethods.isEmpty()) {
-            invoker = this.timed(invoker, timedmethods);
+        if (!timedMethods.isEmpty()) {
+            invoker = this.timed(invoker, timedMethods);
         }
 
-        if (!meteredmethods.isEmpty()) {
-            invoker = this.metered(invoker, meteredmethods);
+        if (!meteredMethods.isEmpty()) {
+            invoker = this.metered(invoker, meteredMethods);
         }
 
-        if (!exceptionmeteredmethods.isEmpty()) {
-            invoker = this.exceptionMetered(invoker, exceptionmeteredmethods);
+        if (!exceptionMeteredMethods.isEmpty()) {
+            invoker = this.exceptionMetered(invoker, exceptionMeteredMethods);
         }
 
         return invoker;

--- a/dropwizard-jakarta-xml-ws/src/test/java/org/kiwiproject/dropwizard/jakarta/xml/ws/BasicAuthenticationInterceptorTest.java
+++ b/dropwizard-jakarta-xml-ws/src/test/java/org/kiwiproject/dropwizard/jakarta/xml/ws/BasicAuthenticationInterceptorTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.when;
 
 import org.apache.cxf.configuration.security.AuthorizationPolicy;
 import org.apache.cxf.interceptor.InterceptorChain;
-import org.apache.cxf.message.Exchange;
 import org.apache.cxf.message.ExchangeImpl;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageImpl;
@@ -111,12 +110,12 @@ class BasicAuthenticationInterceptorTest {
     }
 
     private Message createEmptyMessage() {
-        Exchange exchange = new ExchangeImpl();
+        var exchange = new ExchangeImpl();
         exchange.setInMessage(inMessageMock);
         exchange.setOutMessage(outMessageMock);
         exchange.setDestination(destinationMock);
 
-        Message message = new MessageImpl();
+        var message = new MessageImpl();
         message.setExchange(exchange);
         message.setInterceptorChain(interceptorChainMock);
         return message;

--- a/dropwizard-jakarta-xml-ws/src/test/java/org/kiwiproject/dropwizard/jakarta/xml/ws/JakartaXmlWsBundleTest.java
+++ b/dropwizard-jakarta-xml-ws/src/test/java/org/kiwiproject/dropwizard/jakarta/xml/ws/JakartaXmlWsBundleTest.java
@@ -69,9 +69,8 @@ class JakartaXmlWsBundleTest {
 
     @Test
     void initializeAndRun() {
-        JakartaXmlWsBundle<?> jwsBundle = new JakartaXmlWsBundle<>("/soap", jwsEnvironment);
+        var jwsBundle = new JakartaXmlWsBundle<>("/soap", jwsEnvironment);
 
-        //noinspection DataFlowIssue
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> jwsBundle.run(null, null))
                 .withMessage("Environment is null");
@@ -95,7 +94,6 @@ class JakartaXmlWsBundleTest {
             }
         };
 
-        //noinspection DataFlowIssue
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> jwsBundle.run(null, null))
                 .withMessage("Environment is null");
@@ -119,7 +117,6 @@ class JakartaXmlWsBundleTest {
                 .isThrownBy(() -> jwsBundle.publishEndpoint(new EndpointBuilder("foo", null)))
                 .withMessage("Service is null");
 
-        //noinspection DataFlowIssue
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> jwsBundle.publishEndpoint(new EndpointBuilder(null, service)))
                 .withMessage("Path is null");
@@ -135,12 +132,11 @@ class JakartaXmlWsBundleTest {
 
     @Test
     void getClient() {
-        JakartaXmlWsBundle<?> jwsBundle = new JakartaXmlWsBundle<>("/soap", jwsEnvironment);
+        var jwsBundle = new JakartaXmlWsBundle<>("/soap", jwsEnvironment);
 
         Class<?> cls = Object.class;
         var url = "http://foo";
 
-        //noinspection DataFlowIssue
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> jwsBundle.getClient(new ClientBuilder<>(null, null)))
                 .withMessage("ServiceClass is null");
@@ -149,7 +145,6 @@ class JakartaXmlWsBundleTest {
                 .isThrownBy(() -> jwsBundle.getClient(new ClientBuilder<>(null, url)))
                 .withMessage("ServiceClass is null");
 
-        //noinspection DataFlowIssue
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> jwsBundle.getClient(new ClientBuilder<>(cls, null)))
                 .withMessage("Address is null");

--- a/dropwizard-jakarta-xml-ws/src/test/java/org/kiwiproject/dropwizard/jakarta/xml/ws/JakartaXmlWsEnvironmentTest.java
+++ b/dropwizard-jakarta-xml-ws/src/test/java/org/kiwiproject/dropwizard/jakarta/xml/ws/JakartaXmlWsEnvironmentTest.java
@@ -333,7 +333,6 @@ class JakartaXmlWsEnvironmentTest {
                 .isThrownBy(() -> new EndpointBuilder("foo", null))
                 .withMessage("Service is null");
 
-        //noinspection DataFlowIssue
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> new EndpointBuilder(null, service))
                 .withMessage("Path is null");


### PR DESCRIPTION
* Rename several local vars in InstrumentedInvokerFactory#create to camelCase, e.g., timedmethods was renamed to timedMethods, for better readability.
* Use 'var' in BasicAuthenticationInterceptorTest and JakartaXmlWsBundleTest.
* Remove redundant "noinspection" warning suppression comments (IntelliJ let me know they are now redundant; at the time they were added, they weren't so clearly IntelliJ's analysis has improved since then).