### PR TITLE
Test cleanup

### DIFF
--- a/dropwizard-jakarta-xml-ws/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/AbstractBuilder.java
+++ b/dropwizard-jakarta-xml-ws/src/main/java/org/kiwiproject/dropwizard/jakarta/xml/ws/AbstractBuilder.java
@@ -93,6 +93,9 @@ public abstract class AbstractBuilder {
 
     /**
      * Enable MTOM for binary attachments.
+     *
+     * @see <a href="https://www.w3.org/TR/soap12-mtom/">SOAP Message Transmission Optimization Mechanism (W3C)</a>
+     * @see <a href="https://en.wikipedia.org/wiki/Message_Transmission_Optimization_Mechanism">MTOM (Wikipedia)</a>
      */
     public AbstractBuilder enableMtom() {
         this.mtomEnabled = true;

--- a/dropwizard-jakarta-xml-ws/src/test/java/org/kiwiproject/dropwizard/jakarta/xml/ws/ClientBuilderTest.java
+++ b/dropwizard-jakarta-xml-ws/src/test/java/org/kiwiproject/dropwizard/jakarta/xml/ws/ClientBuilderTest.java
@@ -1,6 +1,7 @@
 package org.kiwiproject.dropwizard.jakarta.xml.ws;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.mock;
 
 import jakarta.xml.ws.handler.Handler;
@@ -29,14 +30,16 @@ class ClientBuilderTest {
                 .cxfOutInterceptors(outInterceptor, outInterceptor)
                 .cxfOutFaultInterceptors(outFaultInterceptor, outFaultInterceptor);
 
-        assertThat(builder.getAddress()).isEqualTo("address");
-        assertThat(builder.getServiceClass()).isEqualTo(Object.class);
-        assertThat(builder.getConnectTimeout()).isEqualTo(1234);
-        assertThat(builder.getReceiveTimeout()).isEqualTo(5678);
-        assertThat(builder.getBindingId()).isEqualTo("binding id");
-        assertThat(builder.getCxfInInterceptors()).contains(inInterceptor, inInterceptor);
-        assertThat(builder.getCxfInFaultInterceptors()).contains(inFaultInterceptor, inFaultInterceptor);
-        assertThat(builder.getCxfOutInterceptors()).contains(outInterceptor, outInterceptor);
-        assertThat(builder.getCxfOutFaultInterceptors()).contains(outFaultInterceptor, outFaultInterceptor);
+        assertAll(
+                () -> assertThat(builder.getAddress()).isEqualTo("address"),
+                () -> assertThat(builder.getServiceClass()).isEqualTo(Object.class),
+                () -> assertThat(builder.getConnectTimeout()).isEqualTo(1234),
+                () -> assertThat(builder.getReceiveTimeout()).isEqualTo(5678),
+                () -> assertThat(builder.getBindingId()).isEqualTo("binding id"),
+                () -> assertThat(builder.getCxfInInterceptors()).contains(inInterceptor, inInterceptor),
+                () -> assertThat(builder.getCxfInFaultInterceptors()).contains(inFaultInterceptor, inFaultInterceptor),
+                () -> assertThat(builder.getCxfOutInterceptors()).contains(outInterceptor, outInterceptor),
+                () -> assertThat(builder.getCxfOutFaultInterceptors()).contains(outFaultInterceptor, outFaultInterceptor)
+        );
     }
 }

--- a/dropwizard-jakarta-xml-ws/src/test/java/org/kiwiproject/dropwizard/jakarta/xml/ws/EndpointBuilderTest.java
+++ b/dropwizard-jakarta-xml-ws/src/test/java/org/kiwiproject/dropwizard/jakarta/xml/ws/EndpointBuilderTest.java
@@ -1,6 +1,7 @@
 package org.kiwiproject.dropwizard.jakarta.xml.ws;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.mock;
 
 import org.apache.cxf.interceptor.Interceptor;
@@ -36,15 +37,17 @@ class EndpointBuilderTest {
                 .cxfOutFaultInterceptors(outFaultInterceptor, outFaultInterceptor)
                 .properties(props);
 
-        assertThat(builder.getPath()).isEqualTo(path);
-        assertThat(builder.getService()).isEqualTo(service);
-        assertThat(builder.publishedEndpointUrl()).isEqualTo(publishedUrl);
-        assertThat(builder.getAuthentication()).isEqualTo(basicAuth);
-        assertThat(builder.getSessionFactory()).isEqualTo(sessionFactory);
-        assertThat(builder.getCxfInInterceptors()).contains(inInterceptor, inInterceptor);
-        assertThat(builder.getCxfInFaultInterceptors()).contains(inFaultInterceptor, inFaultInterceptor);
-        assertThat(builder.getCxfOutInterceptors()).contains(outInterceptor, outInterceptor);
-        assertThat(builder.getCxfOutFaultInterceptors()).contains(outFaultInterceptor, outFaultInterceptor);
-        assertThat(builder.getProperties()).containsEntry("key", "value");
+        assertAll(
+                () -> assertThat(builder.getPath()).isEqualTo(path),
+                () -> assertThat(builder.getService()).isEqualTo(service),
+                () -> assertThat(builder.publishedEndpointUrl()).isEqualTo(publishedUrl),
+                () -> assertThat(builder.getAuthentication()).isEqualTo(basicAuth),
+                () -> assertThat(builder.getSessionFactory()).isEqualTo(sessionFactory),
+                () -> assertThat(builder.getCxfInInterceptors()).contains(inInterceptor, inInterceptor),
+                () -> assertThat(builder.getCxfInFaultInterceptors()).contains(inFaultInterceptor, inFaultInterceptor),
+                () -> assertThat(builder.getCxfOutInterceptors()).contains(outInterceptor, outInterceptor),
+                () -> assertThat(builder.getCxfOutFaultInterceptors()).contains(outFaultInterceptor, outFaultInterceptor),
+                () -> assertThat(builder.getProperties()).containsEntry("key", "value")
+        );
     }
 }

--- a/dropwizard-jakarta-xml-ws/src/test/java/org/kiwiproject/dropwizard/jakarta/xml/ws/JakartaXmlWsBundleTest.java
+++ b/dropwizard-jakarta-xml-ws/src/test/java/org/kiwiproject/dropwizard/jakarta/xml/ws/JakartaXmlWsBundleTest.java
@@ -2,6 +2,7 @@ package org.kiwiproject.dropwizard.jakarta.xml.ws;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.startsWith;
@@ -51,20 +52,22 @@ class JakartaXmlWsBundleTest {
 
     @Test
     void constructorArgumentChecks() {
-        assertThatIllegalArgumentException()
-                .isThrownBy(() -> new JakartaXmlWsBundle<>(null, jwsEnvironment))
-                .withMessage("Servlet path is null");
+        assertAll(
+                () -> assertThatIllegalArgumentException()
+                        .isThrownBy(() -> new JakartaXmlWsBundle<>(null, jwsEnvironment))
+                        .withMessage("Servlet path is null"),
 
-        assertThatIllegalArgumentException()
-                .isThrownBy(() -> new JakartaXmlWsBundle<>("soap", jwsEnvironment))
-                .withMessage("soap is not an absolute path");
+                () -> assertThatIllegalArgumentException()
+                        .isThrownBy(() -> new JakartaXmlWsBundle<>("soap", jwsEnvironment))
+                        .withMessage("soap is not an absolute path"),
 
-        assertThatIllegalArgumentException()
-                .isThrownBy(() -> new JakartaXmlWsBundle<>("/soap", null))
-                .withMessage("jwsEnvironment is null");
+                () -> assertThatIllegalArgumentException()
+                        .isThrownBy(() -> new JakartaXmlWsBundle<>("/soap", null))
+                        .withMessage("jwsEnvironment is null"),
 
-        assertThatCode(() -> new JakartaXmlWsBundle<>("/soap", jwsEnvironment))
-                .doesNotThrowAnyException();
+                () -> assertThatCode(() -> new JakartaXmlWsBundle<>("/soap", jwsEnvironment))
+                        .doesNotThrowAnyException()
+        );
     }
 
     @Test
@@ -112,17 +115,20 @@ class JakartaXmlWsBundleTest {
     void publishEndpoint() {
         var jwsBundle = new JakartaXmlWsBundle<>("/soap", jwsEnvironment);
         var service = new Object();
-        assertThatIllegalArgumentException()
-                .isThrownBy(() -> jwsBundle.publishEndpoint(new EndpointBuilder("foo", null)))
-                .withMessage("Service is null");
 
-        assertThatIllegalArgumentException()
-                .isThrownBy(() -> jwsBundle.publishEndpoint(new EndpointBuilder(null, service)))
-                .withMessage("Path is null");
+        assertAll(
+                () -> assertThatIllegalArgumentException()
+                        .isThrownBy(() -> jwsBundle.publishEndpoint(new EndpointBuilder("foo", null)))
+                        .withMessage("Service is null"),
 
-        assertThatIllegalArgumentException()
-                .isThrownBy(() -> jwsBundle.publishEndpoint(new EndpointBuilder("   ", service)))
-                .withMessage("Path is empty");
+                () -> assertThatIllegalArgumentException()
+                        .isThrownBy(() -> jwsBundle.publishEndpoint(new EndpointBuilder(null, service)))
+                        .withMessage("Path is null"),
+
+                () -> assertThatIllegalArgumentException()
+                        .isThrownBy(() -> jwsBundle.publishEndpoint(new EndpointBuilder("   ", service)))
+                        .withMessage("Path is empty")
+        );
 
         var builder = mock(EndpointBuilder.class);
         jwsBundle.publishEndpoint(builder);
@@ -136,21 +142,23 @@ class JakartaXmlWsBundleTest {
         Class<?> cls = Object.class;
         var url = "http://foo";
 
-        assertThatIllegalArgumentException()
-                .isThrownBy(() -> jwsBundle.getClient(new ClientBuilder<>(null, null)))
-                .withMessage("ServiceClass is null");
+        assertAll(
+                () -> assertThatIllegalArgumentException()
+                        .isThrownBy(() -> jwsBundle.getClient(new ClientBuilder<>(null, null)))
+                        .withMessage("ServiceClass is null"),
 
-        assertThatIllegalArgumentException()
-                .isThrownBy(() -> jwsBundle.getClient(new ClientBuilder<>(null, url)))
-                .withMessage("ServiceClass is null");
+                () -> assertThatIllegalArgumentException()
+                        .isThrownBy(() -> jwsBundle.getClient(new ClientBuilder<>(null, url)))
+                        .withMessage("ServiceClass is null"),
 
-        assertThatIllegalArgumentException()
-                .isThrownBy(() -> jwsBundle.getClient(new ClientBuilder<>(cls, null)))
-                .withMessage("Address is null");
+                () -> assertThatIllegalArgumentException()
+                        .isThrownBy(() -> jwsBundle.getClient(new ClientBuilder<>(cls, null)))
+                        .withMessage("Address is null"),
 
-        assertThatIllegalArgumentException()
-                .isThrownBy(() -> jwsBundle.getClient(new ClientBuilder<>(cls, " ")))
-                .withMessage("Address is empty");
+                () -> assertThatIllegalArgumentException()
+                        .isThrownBy(() -> jwsBundle.getClient(new ClientBuilder<>(cls, " ")))
+                        .withMessage("Address is empty")
+        );
 
         var builder = new ClientBuilder<>(cls, url);
         jwsBundle.getClient(builder);


### PR DESCRIPTION
* Make use of Assertions.assertAll to group related assertions
* Split InstrumentedInvokerFactoryTest#exceptionMeteredAnnotation test into separate tests: one where exception is thrown, one where exception is not thrown.
* Split JakartaXmlWsEnvironmentTest#getClient test into separate tests: one for the "simple" client and one for the "complex" client with handler, interceptors, MTOM, etc.
* Add MTOM references in Javadoc on AbstractBuilder#enableMtom