### PR TITLE
Use cxf-bom to control Apache CXF versions

### DIFF
--- a/dropwizard-jakarta-xml-ws-example/pom.xml
+++ b/dropwizard-jakarta-xml-ws-example/pom.xml
@@ -56,7 +56,6 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-features-logging</artifactId>
-            <version>${cxf.version}</version>
         </dependency>
 
         <dependency>
@@ -75,7 +74,7 @@
             <plugin>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-codegen-plugin</artifactId>
-                <version>${cxf.version}</version>
+                <version>${cxf.codegen.plugin.version}</version>
                 <executions>
                     <execution>
                         <id>generate-sources</id>

--- a/dropwizard-jakarta-xml-ws/pom.xml
+++ b/dropwizard-jakarta-xml-ws/pom.xml
@@ -32,13 +32,11 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
-            <version>${cxf.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>${cxf.version}</version>
         </dependency>
 
         <dependency>
@@ -91,14 +89,12 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-testutils</artifactId>
-            <version>${cxf.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-local</artifactId>
-            <version>${cxf.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
 
     <properties>
         <cxf.version>4.0.6</cxf.version>
+        <cxf.codegen.plugin.version>4.0.6</cxf.codegen.plugin.version>
 
         <!--
         NOTE:
@@ -91,6 +92,14 @@
                 <groupId>org.kiwiproject</groupId>
                 <artifactId>kiwi-bom</artifactId>
                 <version>${kiwi-bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.cxf</groupId>
+                <artifactId>cxf-bom</artifactId>
+                <version>${cxf.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
* Use cxf-bom for CXF deps, except the plugin
* Add a separate version property for the CXF codegen plugin, since it's not in the BOM

Closes #213