### PR TITLE
Add cooldown periods to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,10 @@ updates:
       - "sleberknight"
       - "chrisrohr"
     open-pull-requests-limit: 10
+    cooldown:
+      semver-patch-days: 5
+      semver-minor-days: 14
+      semver-major-days: 30
     commit-message:
       prefix: "chore(deps)"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Add cooldown periods to the Dependabot configuration to reduce noise from immediate version bump PRs. This gives time for issues with new releases to surface in the community before we adopt them. Patch: 5 days, minor: 14 days, major: 30 days.