### PR TITLE
deps: Bump cxf version from 4.1.5 to 4.1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     </modules>
 
     <properties>
-        <cxf.version>4.1.5</cxf.version>
+        <cxf.version>4.1.7</cxf.version>
 
         <jakarta.persistence-api.version>3.2.0</jakarta.persistence-api.version>
         <jakarta.transaction-api.version>2.0.1</jakarta.transaction-api.version>


### PR DESCRIPTION
This fixes several CVEs in Apache Neethi which is a transitive dependency of cxf-rt-ws-policy