### PR TITLE
chore: exclude org.kiwiproject from Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,8 @@ updates:
       semver-patch-days: 5
       semver-minor-days: 14
       semver-major-days: 30
+      exclude:
+        - "org.kiwiproject:*"
     commit-message:
       prefix: "chore(deps)"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Exclude org.kiwiproject dependencies from the Dependabot cooldown period so that kiwiproject library updates are not delayed.

This mirrors the same change already made in kiwiproject-changelog.